### PR TITLE
simplify ArchUnit tests

### DIFF
--- a/core/src/test/java/org/jobrunr/architecture/PackageDependenciesTest.java
+++ b/core/src/test/java/org/jobrunr/architecture/PackageDependenciesTest.java
@@ -3,7 +3,12 @@ package org.jobrunr.architecture;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeTests;
+import com.tngtech.archunit.core.importer.Location;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
+import org.jobrunr.architecture.PackageDependenciesTest.DoNotIncludeTestFixtures;
 import org.jobrunr.JobRunrException;
 import org.jobrunr.server.BackgroundJobPerformer;
 import org.jobrunr.utils.reflection.autobox.InstantForOracleTypeAutoboxer;
@@ -12,149 +17,120 @@ import org.junit.jupiter.api.Test;
 
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAnyPackage;
-import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
+@AnalyzeClasses(packages = "org.jobrunr", importOptions = {DoNotIncludeTests.class, DoNotIncludeTestFixtures.class})
 class PackageDependenciesTest {
 
-    private static final ImportOption DO_NOT_INCLUDE_TEST_FIXTURES = location -> !location.toString().contains("test-fixtures");
-
-    private JavaClasses classes;
-
-    @BeforeEach
-    void setUpJavaClasses() {
-        classes = new ClassFileImporter()
-                .withImportOption(DO_NOT_INCLUDE_TESTS)
-                .withImportOption(DO_NOT_INCLUDE_TEST_FIXTURES)
-                .importPackages("org.jobrunr");
+    static class DoNotIncludeTestFixtures implements ImportOption {
+        @Override
+        public boolean includes(Location location) {
+            return !location.toString().contains("test-fixtures");
+        }
     }
 
-    @Test
-    void jobRunrConfigurationDependenciesTest() {
-        ArchRule configurationClasses = classes()
+    @ArchTest
+    ArchRule jobRunrConfigurationDependenciesTest = classes()
                 .that().resideInAPackage("org.jobrunr.configuration..")
                 .should().onlyDependOnClassesThat().resideInAnyPackage("org.jobrunr..", "java..");
 
-        configurationClasses.check(classes);
-    }
-
-    @Test
-    void jobRunrDashboardClassesDependenciesTest() {
-        ArchRule dashboardClasses = classes()
+    @ArchTest
+    ArchRule jobRunrDashboardClassesDependenciesTest = classes()
                 .that().resideInAPackage("org.jobrunr.dashboard..")
                 .should().onlyDependOnClassesThat().resideInAnyPackage("org.jobrunr..", "com.sun..", "org.slf4j..", "java..");
-        dashboardClasses.check(classes);
-    }
 
-    @Test
-    void jobRunrJobsClassesDependenciesTest() {
-        ArchRule jobClassesExceptJobDetails = classes()
+    @ArchTest
+    ArchRule jobRunrJobsClassesDependenciesTest = classes()
                 .that().resideInAPackage("org.jobrunr.jobs..").and().resideOutsideOfPackage("org.jobrunr.jobs.details..")
                 .should().onlyDependOnClassesThat().resideInAnyPackage("org.jobrunr..", "org.slf4j..", "java..");
-        jobClassesExceptJobDetails.check(classes);
 
-        ArchRule jobDetailsClasses = classes()
+    @ArchTest
+    ArchRule jobRunrJobsDetailsClassesDependenciesTest = classes()
                 .that().resideInAPackage("org.jobrunr.jobs.details..")
                 .should().onlyDependOnClassesThat().resideInAnyPackage("org.jobrunr..", "org.objectweb.asm..", "org.slf4j..", "java..");
-        jobDetailsClasses.check(classes);
-    }
 
-    @Test
-    void jobRunrSchedulingClassesDependenciesTest() {
-        ArchRule jobSchedulingClasses = classes()
+    @ArchTest
+    ArchRule jobRunrSchedulingClassesDependenciesTest = classes()
                 .that().resideInAPackage("org.jobrunr.scheduling..")
                 .should().onlyDependOnClassesThat().resideInAnyPackage("org.jobrunr..", "org.slf4j..", "java..");
-        jobSchedulingClasses.check(classes);
 
-        ArchRule jobSchedulingClassesShouldNotDependOnServerClasses = noClasses()
+    @ArchTest
+    ArchRule jobSchedulingClassesShouldNotDependOnServerClasses = noClasses()
                 .that().resideInAPackage("org.jobrunr.scheduling..")
                 .should().dependOnClassesThat().resideInAnyPackage("org.jobrunr.server..");
-        jobSchedulingClassesShouldNotDependOnServerClasses.check(classes);
-    }
 
-    @Test
-    void jobRunrServerClassesDependenciesTest() {
-        ArchRule jobServerClassesWithoutJmx = classes()
+    @ArchTest
+    ArchRule jobRunrServerClassesDependenciesTest = classes()
                 .that().resideInAPackage("org.jobrunr.server..").and().resideOutsideOfPackage("org.jobrunr.server.jmx..")
                 .should().onlyDependOnClassesThat().resideInAnyPackage("org.jobrunr..", "org.slf4j..", "java..");
-        jobServerClassesWithoutJmx.check(classes);
 
-        ArchRule jobServerJmxClasses = classes()
+    @ArchTest
+    ArchRule jobRunrServerJmxClassesDependenciesTest = classes()
                 .that().resideInAPackage("org.jobrunr.server.jmx..")
                 .should().onlyDependOnClassesThat().resideInAnyPackage("org.jobrunr..", "java..", "javax.management..");
-        jobServerJmxClasses.check(classes);
 
-        ArchRule jobServerClassesShouldNotDependOnSchedulingClasses = noClasses()
+    @ArchTest
+    ArchRule jobServerClassesShouldNotDependOnSchedulingClasses = noClasses()
                 .that().resideInAPackage("org.jobrunr.server..").and().areNotAssignableFrom(BackgroundJobPerformer.class)
                 .should().dependOnClassesThat().resideInAnyPackage("org.jobrunr.scheduling..");
-        jobServerClassesShouldNotDependOnSchedulingClasses.check(classes);
-    }
 
-    @Test
-    void jobRunrStorageClassesDependenciesTest() {
-        ArchRule jobStorageClasses = classes()
+    @ArchTest
+    ArchRule jobRunrStorageClassesDependenciesTest = classes()
                 .that().resideInAPackage("org.jobrunr.storage")
                 .should().onlyDependOnClassesThat().resideInAnyPackage("org.jobrunr.jobs..", "org.jobrunr.storage..", "org.jobrunr.utils..", "org.jobrunr.server.jmx..", "org.slf4j..", "java..");
-        jobStorageClasses.check(classes);
 
-        ArchRule elasticSearchClasses = classes()
+    @ArchTest
+    ArchRule jobRunrStorageElasticSearchClassesDependenciesTest = classes()
                 .that().resideInAPackage("org.jobrunr.storage.nosql.elasticsearch")
                 .should().onlyDependOnClassesThat().resideInAnyPackage("org.jobrunr.jobs..", "org.jobrunr.storage..", "org.jobrunr.utils..", "org.elasticsearch..", "org.apache.http..", "org.slf4j..", "java..");
-        elasticSearchClasses.check(classes);
 
-        ArchRule mongoClasses = classes()
+    @ArchTest
+    ArchRule jobRunrStorageMongoClassesDependenciesTest = classes()
                 .that().resideInAPackage("org.jobrunr.storage.nosql.mongo")
                 .should().onlyDependOnClassesThat(
                         resideInAnyPackage("org.jobrunr.jobs..", "org.jobrunr.storage..", "org.jobrunr.utils..", "com.mongodb..", "org.bson..", "org.slf4j..", "java..", "")
                                 .or(are(equivalentTo(JobRunrException.class)))
-                );
-        mongoClasses.check(classes); // see https://github.com/TNG/ArchUnit/issues/519
+                ); // see https://github.com/TNG/ArchUnit/issues/519
 
-
-        ArchRule jedisClasses = classes()
+    @ArchTest
+    ArchRule jobRunrStorageRedisClassesDependenciesTest = classes()
                 .that().resideInAPackage("org.jobrunr.storage.nosql.redis")
                 .and().haveSimpleNameStartingWith("Jedis")
                 .should().onlyDependOnClassesThat().resideInAnyPackage("org.jobrunr.jobs..", "org.jobrunr.storage..", "org.jobrunr.utils..", "redis.clients..", "org.slf4j..", "java..");
-        jedisClasses.check(classes);
 
-        ArchRule lettuceClasses = classes()
+    @ArchTest
+    ArchRule jobRunrStorageRedisLettuceClassesDependenciesTest = classes()
                 .that().resideInAPackage("org.jobrunr.storage.nosql.redis")
                 .and().haveSimpleNameStartingWith("Lettuce")
                 .should().onlyDependOnClassesThat().resideInAnyPackage("org.jobrunr.jobs..", "org.jobrunr.storage..", "org.jobrunr.utils..", "io.lettuce..", "org.apache.commons.pool2..", "org.slf4j..", "java..");
-        lettuceClasses.check(classes);
 
-        ArchRule sqlClasses = classes()
+    @ArchTest
+    ArchRule jobRunrStorageSqlClassesDependenciesTest = classes()
                 .that().resideInAnyPackage("org.jobrunr.storage.sql..")
                 .and().resideOutsideOfPackage("org.jobrunr.storage.sql.common..")
                 .should().onlyDependOnClassesThat().resideInAnyPackage("org.jobrunr.jobs..", "org.jobrunr.storage..", "org.jobrunr.utils..", "javax.sql..", "org.slf4j..", "java..");
-        sqlClasses.check(classes);
-    }
 
-    @Test
-    void jobRunrUtilsClassesDependenciesTest() {
-        ArchRule jobUtilsClasses = classes()
+    @ArchTest
+    ArchRule jobRunrUtilsClassesDependenciesTest = classes()
                 .that().resideInAPackage("org.jobrunr.utils..")
                 .and().resideOutsideOfPackage("org.jobrunr.utils.mapper..")
                 .and().doNotHaveFullyQualifiedName(InstantForOracleTypeAutoboxer.class.getName())
                 .should().onlyDependOnClassesThat().resideInAnyPackage("org.jobrunr..", "org.slf4j..", "java..");
-        jobUtilsClasses.check(classes);
 
-        ArchRule jobUtilGsonMapperClasses = classes()
+    @ArchTest
+    ArchRule jobRunrUtilsGsonMapperClassesDependenciesTest = classes()
                 .that().resideInAPackage("org.jobrunr.utils.mapper.gson..")
                 .should().onlyDependOnClassesThat().resideInAnyPackage("org.jobrunr..", "com.google.gson..", "java..", "");
-        jobUtilGsonMapperClasses.check(classes);
 
-        ArchRule jobUtilJacksonMapperClasses = classes()
+    @ArchTest
+    ArchRule jobRunrUtilsJacksonMapperClassesDependenciesTest = classes()
                 .that().resideInAPackage("org.jobrunr.utils.mapper.jackson..")
                 .should().onlyDependOnClassesThat().resideInAnyPackage("org.jobrunr..", "com.fasterxml..", "java..");
-        jobUtilJacksonMapperClasses.check(classes);
 
-        ArchRule jobUtilJsonBMapperClasses = classes()
+    @ArchTest
+    ArchRule jobRunrUtilsJsonBMapperClassesDependenciesTest = classes()
                 .that().resideInAPackage("org.jobrunr.utils.mapper.jsonb..")
                 .should().onlyDependOnClassesThat().resideInAnyPackage("org.jobrunr..", "javax.json..", "java..");
-        jobUtilJsonBMapperClasses.check(classes);
-    }
-
 }


### PR DESCRIPTION
use [ArchUnit's JUnit-support](https://www.archunit.org/userguide/html/000_Index.html#_junit_support) via `@ArchTest` so that we don't have to manually maintain the `JavaClasses classes` and call `rule.check(classes)` for each `ArchRule rule`