### PR TITLE
Add support to secured dashboard

### DIFF
--- a/core/src/main/java/org/jobrunr/dashboard/JobRunrDashboardWebServerConfiguration.java
+++ b/core/src/main/java/org/jobrunr/dashboard/JobRunrDashboardWebServerConfiguration.java
@@ -5,6 +5,8 @@ package org.jobrunr.dashboard;
  */
 public class JobRunrDashboardWebServerConfiguration {
     int port = 8000;
+    String login = null;
+    String password = null;
 
     private JobRunrDashboardWebServerConfiguration() {
 
@@ -27,6 +29,28 @@ public class JobRunrDashboardWebServerConfiguration {
      */
     public JobRunrDashboardWebServerConfiguration andPort(int port) {
         this.port = port;
+        return this;
+    }
+
+    /**
+     * Specifies the login which the JobRunrDashboard will ask
+     *
+     * @param login the login which the JobRunrDashboard will ask
+     * @return the same configuration instance which provides a fluent api
+     */
+    public JobRunrDashboardWebServerConfiguration andLogin(String login) {
+        this.login = login;
+        return this;
+    }
+
+    /**
+     * Specifies the password on which the JobRunrDashboard will ask
+     *
+     * @param password the password which the JobRunrDashboard will ask
+     * @return the same configuration instance which provides a fluent api
+     */
+    public JobRunrDashboardWebServerConfiguration andPassword(String password) {
+        this.password = password;
         return this;
     }
 }

--- a/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/autoconfigure/JobRunrAutoConfiguration.java
+++ b/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/autoconfigure/JobRunrAutoConfiguration.java
@@ -85,7 +85,9 @@ public class JobRunrAutoConfiguration {
     @ConditionalOnProperty(prefix = "org.jobrunr.dashboard", name = "enabled", havingValue = "true")
     public JobRunrDashboardWebServerConfiguration dashboardWebServerConfiguration(JobRunrProperties properties) {
         return usingStandardDashboardConfiguration()
-                .andPort(properties.getDashboard().getPort());
+                .andPort(properties.getDashboard().getPort())
+                .andLogin(properties.getDashboard().getLogin())
+                .andPassword(properties.getDashboard().getPassword());
     }
 
     @Bean

--- a/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/autoconfigure/JobRunrProperties.java
+++ b/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/autoconfigure/JobRunrProperties.java
@@ -149,6 +149,16 @@ public class JobRunrProperties {
          */
         private int port = 8000;
 
+        /**
+         * The login wich the Dashboard should ask
+         */
+        private String login = null;
+
+        /**
+         * The password wich the Dashboard should ask
+         */
+        private String password = null;
+
         public boolean isEnabled() {
             return enabled;
         }
@@ -163,6 +173,23 @@ public class JobRunrProperties {
 
         public void setPort(int port) {
             this.port = port;
+        }
+
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+
+        public String getLogin() {
+            return login;
+        }
+
+        public void setLogin(String login) {
+            this.login = login;
         }
     }
 


### PR DESCRIPTION
Add support to secured dashboard with basic authentication.
If org.jobrunr.dashboard.login and org.jobrunr.dashboard.password properties are used, the basic authentication is enable with this informations.

Linked issue : #66 