### PR TITLE
Explicitly commit in case of autoCommit=false.

### DIFF
--- a/core/src/main/java/org/jobrunr/storage/sql/common/JobTable.java
+++ b/core/src/main/java/org/jobrunr/storage/sql/common/JobTable.java
@@ -197,6 +197,9 @@ public class JobTable extends Sql<Job> {
     void insertOneJob(Job jobToSave) {
         try (Connection conn = dataSource.getConnection()) {
             insert(conn, jobToSave, "into jobrunr_jobs values (:id, :version, :jobAsJson, :jobSignature, :state, :createdAt, :updatedAt, :scheduledAt, :recurringJobId)");
+            if (!conn.getAutoCommit()) {
+                conn.commit();
+            }
         } catch (SQLException e) {
             throw new StorageException(e);
         }
@@ -205,6 +208,9 @@ public class JobTable extends Sql<Job> {
     void updateOneJob(Job jobToSave) {
         try (Connection conn = dataSource.getConnection()) {
             update(conn, jobToSave, "jobrunr_jobs SET version = :version, jobAsJson = :jobAsJson, state = :state, updatedAt =:updatedAt, scheduledAt = :scheduledAt WHERE id = :id and version = :previousVersion");
+            if (!conn.getAutoCommit()) {
+                conn.commit();
+            }
         } catch (SQLException e) {
             throw new StorageException(e);
         }

--- a/core/src/main/java/org/jobrunr/storage/sql/common/db/Sql.java
+++ b/core/src/main/java/org/jobrunr/storage/sql/common/db/Sql.java
@@ -110,6 +110,9 @@ public class Sql<T> {
     public void insert(T item, String statement) {
         try (final Connection conn = dataSource.getConnection()) {
             insertOrUpdate(conn, item, INSERT + statement);
+            if (!conn.getAutoCommit()) {
+                conn.commit();
+            }
         } catch (SQLException e) {
             throw new StorageException(e);
         }
@@ -126,6 +129,9 @@ public class Sql<T> {
     public void update(String statement) {
         try (final Connection conn = dataSource.getConnection()) {
             insertOrUpdate(conn, null, UPDATE + statement);
+            if (!conn.getAutoCommit()) {
+                conn.commit();
+            }
         } catch (SQLException e) {
             throw new StorageException(e);
         }
@@ -134,6 +140,9 @@ public class Sql<T> {
     public void update(T item, String statement) {
         try (final Connection conn = dataSource.getConnection()) {
             insertOrUpdate(conn, item, UPDATE + statement);
+            if (!conn.getAutoCommit()) {
+                conn.commit();
+            }
         } catch (SQLException e) {
             throw new StorageException(e);
         }
@@ -149,7 +158,11 @@ public class Sql<T> {
 
     public int delete(String statement) {
         try (final Connection conn = dataSource.getConnection()) {
-            return delete(conn, statement);
+            int delete = delete(conn, statement);
+            if (!conn.getAutoCommit()) {
+                conn.commit();
+            }
+            return delete;
         } catch (SQLException e) {
             throw new StorageException(e);
         }

--- a/core/src/test/java/org/jobrunr/storage/sql/h2/C3p0AutoCommitFalseH2StorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/h2/C3p0AutoCommitFalseH2StorageProviderTest.java
@@ -1,0 +1,19 @@
+package org.jobrunr.storage.sql.h2;
+
+import com.mchange.v2.c3p0.ComboPooledDataSource;
+
+import javax.sql.DataSource;
+
+public class C3p0AutoCommitFalseH2StorageProviderTest extends C3p0H2StorageProviderTest {
+
+    private static ComboPooledDataSource dataSource;
+
+    @Override
+    protected DataSource getDataSource() {
+        if (dataSource == null) {
+            dataSource = createDataSource();
+            dataSource.setAutoCommitOnClose(false);
+        }
+        return dataSource;
+    }
+}

--- a/core/src/test/java/org/jobrunr/storage/sql/h2/C3p0H2StorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/h2/C3p0H2StorageProviderTest.java
@@ -13,11 +13,16 @@ public class C3p0H2StorageProviderTest extends SqlStorageProviderTest {
     @Override
     protected DataSource getDataSource() {
         if (dataSource == null) {
-            dataSource = new ComboPooledDataSource();
-            dataSource.setJdbcUrl("jdbc:h2:/tmp/test-c3p0");
-            dataSource.setUser("sa");
-            dataSource.setPassword("sa");
+            dataSource = createDataSource();
         }
+        return dataSource;
+    }
+
+    protected ComboPooledDataSource createDataSource() {
+        ComboPooledDataSource dataSource = new ComboPooledDataSource();
+        dataSource.setJdbcUrl("jdbc:h2:/tmp/test-c3p0");
+        dataSource.setUser("sa");
+        dataSource.setPassword("sa");
         return dataSource;
     }
 

--- a/core/src/test/java/org/jobrunr/storage/sql/h2/CommonsDbcpAutoCommitFalseH2StorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/h2/CommonsDbcpAutoCommitFalseH2StorageProviderTest.java
@@ -1,0 +1,19 @@
+package org.jobrunr.storage.sql.h2;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+
+import javax.sql.DataSource;
+
+public class CommonsDbcpAutoCommitFalseH2StorageProviderTest extends CommonsDbcpH2StorageProviderTest {
+
+    private static BasicDataSource dataSource;
+
+    @Override
+    protected DataSource getDataSource() {
+        if (dataSource == null) {
+            dataSource = createDataSource();
+            dataSource.setDefaultAutoCommit(false);
+        }
+        return dataSource;
+    }
+}

--- a/core/src/test/java/org/jobrunr/storage/sql/h2/CommonsDbcpH2StorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/h2/CommonsDbcpH2StorageProviderTest.java
@@ -14,11 +14,16 @@ public class CommonsDbcpH2StorageProviderTest extends SqlStorageProviderTest {
     @Override
     protected DataSource getDataSource() {
         if (dataSource == null) {
-            dataSource = new BasicDataSource();
-            dataSource.setUrl("jdbc:h2:/tmp/test-commonsdbcp");
-            dataSource.setUsername("sa");
-            dataSource.setPassword("sa");
+            dataSource = createDataSource();
         }
+        return dataSource;
+    }
+
+    protected BasicDataSource createDataSource() {
+        BasicDataSource dataSource = new BasicDataSource();
+        dataSource.setUrl("jdbc:h2:/tmp/test-commonsdbcp");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("sa");
         return dataSource;
     }
 

--- a/core/src/test/java/org/jobrunr/storage/sql/h2/HikariH2AutoCommitFalseStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/h2/HikariH2AutoCommitFalseStorageProviderTest.java
@@ -1,0 +1,21 @@
+package org.jobrunr.storage.sql.h2;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+import javax.sql.DataSource;
+
+public class HikariH2AutoCommitFalseStorageProviderTest extends HikariH2StorageProviderTest {
+
+    private static HikariDataSource dataSource;
+
+    @Override
+    protected DataSource getDataSource() {
+        if (dataSource == null) {
+            HikariConfig config = new HikariConfig();
+            config.setAutoCommit(false);
+            dataSource = createDataSource(config);
+        }
+        return dataSource;
+    }
+}

--- a/core/src/test/java/org/jobrunr/storage/sql/h2/HikariH2StorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/h2/HikariH2StorageProviderTest.java
@@ -15,13 +15,16 @@ public class HikariH2StorageProviderTest extends SqlStorageProviderTest {
     protected DataSource getDataSource() {
         if (dataSource == null) {
             HikariConfig config = new HikariConfig();
-
-            config.setJdbcUrl("jdbc:h2:/tmp/test-hikari");
-            config.setUsername("sa");
-            config.setPassword("sa");
-            dataSource = new HikariDataSource(config);
+            dataSource = createDataSource(config);
         }
         return dataSource;
+    }
+
+    protected HikariDataSource createDataSource(HikariConfig config) {
+        config.setJdbcUrl("jdbc:h2:/tmp/test-hikari");
+        config.setUsername("sa");
+        config.setPassword("sa");
+        return new HikariDataSource(config);
     }
 
     @AfterAll

--- a/core/src/test/java/org/jobrunr/storage/sql/h2/TomcatJdbcPoolAutoCommitFalseH2StorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/h2/TomcatJdbcPoolAutoCommitFalseH2StorageProviderTest.java
@@ -1,0 +1,17 @@
+package org.jobrunr.storage.sql.h2;
+
+import org.apache.tomcat.jdbc.pool.DataSource;
+
+public class TomcatJdbcPoolAutoCommitFalseH2StorageProviderTest extends TomcatJdbcPoolH2StorageProviderTest {
+
+    private static DataSource dataSource;
+
+    @Override
+    protected DataSource getDataSource() {
+        if (dataSource == null) {
+            dataSource = createDataSource();
+            dataSource.setDefaultAutoCommit(false);
+        }
+        return dataSource;
+    }
+}

--- a/core/src/test/java/org/jobrunr/storage/sql/h2/TomcatJdbcPoolH2StorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/h2/TomcatJdbcPoolH2StorageProviderTest.java
@@ -11,11 +11,16 @@ public class TomcatJdbcPoolH2StorageProviderTest extends SqlStorageProviderTest 
     @Override
     protected DataSource getDataSource() {
         if (dataSource == null) {
-            dataSource = new DataSource();
-            dataSource.setUrl("jdbc:h2:/tmp/test-tomcatjdbcpool");
-            dataSource.setUsername("sa");
-            dataSource.setPassword("sa");
+            dataSource = createDataSource();
         }
+        return dataSource;
+    }
+
+    protected DataSource createDataSource() {
+        DataSource dataSource = new DataSource();
+        dataSource.setUrl("jdbc:h2:/tmp/test-tomcatjdbcpool");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("sa");
         return dataSource;
     }
 


### PR DESCRIPTION
Explicitly commit in all updating operations in `Sql` and all its subclasses.

Fixes #128 