### PR TITLE
Increase the visibility of fields.

### DIFF
--- a/core/src/main/java/org/jobrunr/storage/sql/common/DefaultSqlStorageProvider.java
+++ b/core/src/main/java/org/jobrunr/storage/sql/common/DefaultSqlStorageProvider.java
@@ -31,9 +31,9 @@ public class DefaultSqlStorageProvider extends AbstractStorageProvider implement
         SKIP_CREATE
     }
 
-    private final DataSource dataSource;
-    private final Dialect dialect;
-    private final String tablePrefix;
+    protected final DataSource dataSource;
+    protected final Dialect dialect;
+    protected final String tablePrefix;
     private final DatabaseOptions databaseOptions;
     private JobMapper jobMapper;
 


### PR DESCRIPTION
The visibility of `getDatabaseCreator()` is `protected` while all parameters it will use are `private`.
And it will be called directly from the constructor, making `getDatabaseCreator()` hardly to override.