### PR TITLE
Add back deprecated method in public configuration for compatibility.

### DIFF
--- a/core/src/main/java/org/jobrunr/server/BackgroundJobServerConfiguration.java
+++ b/core/src/main/java/org/jobrunr/server/BackgroundJobServerConfiguration.java
@@ -61,6 +61,19 @@ public class BackgroundJobServerConfiguration {
      *
      * @param backgroundJobServerWorkerPolicy the backgroundJobServerWorkerPolicy
      * @return the same configuration instance which provides a fluent api
+     * @deprecated Use {@link #andBackgroundJobServerWorkerPolicy} instead.
+     */
+    @Deprecated
+    public BackgroundJobServerConfiguration andWorkerCountPolicy(BackgroundJobServerWorkerPolicy backgroundJobServerWorkerPolicy) {
+        return andBackgroundJobServerWorkerPolicy(backgroundJobServerWorkerPolicy);
+    }
+
+    /**
+     * Allows to set the backgroundJobServerWorkerPolicy for the BackgroundJobServer. The backgroundJobServerWorkerPolicy will determine
+     * the final WorkDistributionStrategy used by the BackgroundJobServer.
+     *
+     * @param backgroundJobServerWorkerPolicy the backgroundJobServerWorkerPolicy
+     * @return the same configuration instance which provides a fluent api
      */
     public BackgroundJobServerConfiguration andBackgroundJobServerWorkerPolicy(BackgroundJobServerWorkerPolicy backgroundJobServerWorkerPolicy) {
         this.backgroundJobServerWorkerPolicy = backgroundJobServerWorkerPolicy;


### PR DESCRIPTION
I think it is good to retain background compatibility while evolving.

Renaming a  public method directly will cause a `MAJOR` version bump in case of following [Semantic Versioning](https://semver.org/#semantic-versioning-200), and I don't think people want to upgrade to a new version of a library just for the more reasonable naming of things :smile: 