### PR TITLE
interacting with popular third-party application monitoring systems.

### DIFF
--- a/jobrunr-spring-boot-starter/build.gradle
+++ b/jobrunr-spring-boot-starter/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     testImplementation 'io.lettuce:lettuce-core'
     testImplementation 'org.mongodb:mongodb-driver-sync'
     testImplementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
-    testImplementation 'io.micrometer:micrometer-registry-prometheus:1.7.2'
+    testImplementation 'io.micrometer:micrometer-core:1.7.2'
 }
 
 java {

--- a/jobrunr-spring-boot-starter/build.gradle
+++ b/jobrunr-spring-boot-starter/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     compileOnly 'org.mongodb:mongodb-driver-sync'
     compileOnly 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
 
+    compileOnly 'io.micrometer:micrometer-core:1.7.2'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.5.1'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'
     testImplementation 'com.google.code.gson:gson'
@@ -29,6 +31,7 @@ dependencies {
     testImplementation 'io.lettuce:lettuce-core'
     testImplementation 'org.mongodb:mongodb-driver-sync'
     testImplementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
+    testImplementation 'io.micrometer:micrometer-registry-prometheus:1.7.2'
 }
 
 java {

--- a/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/autoconfigure/metric/JobRunrMetricsAutoConfiguration.java
+++ b/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/autoconfigure/metric/JobRunrMetricsAutoConfiguration.java
@@ -1,6 +1,5 @@
 package org.jobrunr.autoconfigure.metric;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import org.jobrunr.autoconfigure.JobRunrAutoConfiguration;
 import org.jobrunr.metric.BackgroundJobServerMetricsBinder;
 import org.jobrunr.metric.StorageProviderMetricsBinder;
@@ -14,20 +13,20 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConditionalOnClass(
-        name = {"io.micrometer.core.instrument.MeterRegistry"}
+        name = {"io.micrometer.core.instrument.Metrics"}
 )
 @AutoConfigureAfter({JobRunrAutoConfiguration.class})
 public class JobRunrMetricsAutoConfiguration {
 
     @Bean
     @ConditionalOnBean({StorageProvider.class})
-    public StorageProviderMetricsBinder storageProviderMetricsBinder(MeterRegistry registry, StorageProvider storageProvider) {
-        return new StorageProviderMetricsBinder(registry, storageProvider);
+    public StorageProviderMetricsBinder storageProviderMetricsBinder(StorageProvider storageProvider) {
+        return new StorageProviderMetricsBinder(storageProvider);
     }
 
     @Bean
     @ConditionalOnBean({BackgroundJobServer.class})
-    public BackgroundJobServerMetricsBinder backgroundJobServerMetricsBinder(MeterRegistry registry, BackgroundJobServer backgroundJobServer) {
-        return new BackgroundJobServerMetricsBinder(registry, backgroundJobServer);
+    public BackgroundJobServerMetricsBinder backgroundJobServerMetricsBinder(BackgroundJobServer backgroundJobServer) {
+        return new BackgroundJobServerMetricsBinder(backgroundJobServer);
     }
 }

--- a/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/autoconfigure/metric/JobRunrMetricsAutoConfiguration.java
+++ b/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/autoconfigure/metric/JobRunrMetricsAutoConfiguration.java
@@ -1,0 +1,33 @@
+package org.jobrunr.autoconfigure.metric;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.jobrunr.autoconfigure.JobRunrAutoConfiguration;
+import org.jobrunr.metric.BackgroundJobServerMetricsBinder;
+import org.jobrunr.metric.StorageProviderMetricsBinder;
+import org.jobrunr.server.BackgroundJobServer;
+import org.jobrunr.storage.StorageProvider;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnClass(
+        name = {"io.micrometer.core.instrument.MeterRegistry"}
+)
+@AutoConfigureAfter({JobRunrAutoConfiguration.class})
+public class JobRunrMetricsAutoConfiguration {
+
+    @Bean
+    @ConditionalOnBean({StorageProvider.class})
+    public StorageProviderMetricsBinder storageProviderMetricsBinder(MeterRegistry registry, StorageProvider storageProvider) {
+        return new StorageProviderMetricsBinder(registry, storageProvider);
+    }
+
+    @Bean
+    @ConditionalOnBean({BackgroundJobServer.class})
+    public BackgroundJobServerMetricsBinder backgroundJobServerMetricsBinder(MeterRegistry registry, BackgroundJobServer backgroundJobServer) {
+        return new BackgroundJobServerMetricsBinder(registry, backgroundJobServer);
+    }
+}

--- a/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/metric/BackgroundJobServerMetricsBinder.java
+++ b/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/metric/BackgroundJobServerMetricsBinder.java
@@ -2,18 +2,17 @@ package org.jobrunr.metric;
 
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.jobrunr.server.BackgroundJobServer;
 
 import javax.annotation.PostConstruct;
 
 public class BackgroundJobServerMetricsBinder {
 
-    private final MeterRegistry registry;
     private final BackgroundJobServer backgroundJobServer;
 
-    public BackgroundJobServerMetricsBinder(MeterRegistry registry, BackgroundJobServer backgroundJobServer) {
-        this.registry = registry;
+    public BackgroundJobServerMetricsBinder(BackgroundJobServer backgroundJobServer) {
         this.backgroundJobServer = backgroundJobServer;
     }
 
@@ -33,13 +32,16 @@ public class BackgroundJobServerMetricsBinder {
         String firstHeartbeat = PREFIX + "first_heartbeat";
         String lastHeartbeat = PREFIX + "last_heartbeat";
 
-        FunctionCounter.builder(pollIntervalInSeconds, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getPollIntervalInSeconds()).tag("id", this.backgroundJobServer.getId().toString()).register(this.registry);
-        FunctionCounter.builder(workerPoolSize, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getWorkerPoolSize()).tag("id", this.backgroundJobServer.getId().toString()).register(this.registry);
-        Gauge.builder(processAllocatedMemory, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getProcessAllocatedMemory()).tag("id", this.backgroundJobServer.getId().toString()).register(this.registry);
-        Gauge.builder(processFreeMemory, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getProcessFreeMemory()).tag("id", this.backgroundJobServer.getId().toString()).register(this.registry);
-        Gauge.builder(systemFreeMemory, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getSystemFreeMemory()).tag("id", this.backgroundJobServer.getId().toString()).register(this.registry);
-        Gauge.builder(systemTotalMemory, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getSystemTotalMemory()).tag("id", this.backgroundJobServer.getId().toString()).register(this.registry);
-        Gauge.builder(firstHeartbeat, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getFirstHeartbeat().getEpochSecond()).tag("id", this.backgroundJobServer.getId().toString()).register(this.registry);
-        Gauge.builder(lastHeartbeat, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getLastHeartbeat().getNano()).tag("id", this.backgroundJobServer.getId().toString()).register(this.registry);
+        SimpleMeterRegistry backgroundJobServerMeter = new SimpleMeterRegistry();
+        FunctionCounter.builder(pollIntervalInSeconds, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getPollIntervalInSeconds()).tag("id", this.backgroundJobServer.getId().toString()).register(backgroundJobServerMeter);
+        FunctionCounter.builder(workerPoolSize, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getWorkerPoolSize()).tag("id", this.backgroundJobServer.getId().toString()).register(backgroundJobServerMeter);
+        Gauge.builder(processAllocatedMemory, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getProcessAllocatedMemory()).tag("id", this.backgroundJobServer.getId().toString()).register(backgroundJobServerMeter);
+        Gauge.builder(processFreeMemory, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getProcessFreeMemory()).tag("id", this.backgroundJobServer.getId().toString()).register(backgroundJobServerMeter);
+        Gauge.builder(systemFreeMemory, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getSystemFreeMemory()).tag("id", this.backgroundJobServer.getId().toString()).register(backgroundJobServerMeter);
+        Gauge.builder(systemTotalMemory, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getSystemTotalMemory()).tag("id", this.backgroundJobServer.getId().toString()).register(backgroundJobServerMeter);
+        Gauge.builder(firstHeartbeat, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getFirstHeartbeat().getEpochSecond()).tag("id", this.backgroundJobServer.getId().toString()).register(backgroundJobServerMeter);
+        Gauge.builder(lastHeartbeat, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getLastHeartbeat().getNano()).tag("id", this.backgroundJobServer.getId().toString()).register(backgroundJobServerMeter);
+
+        Metrics.addRegistry(backgroundJobServerMeter);
     }
 }

--- a/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/metric/BackgroundJobServerMetricsBinder.java
+++ b/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/metric/BackgroundJobServerMetricsBinder.java
@@ -1,0 +1,45 @@
+package org.jobrunr.metric;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.jobrunr.server.BackgroundJobServer;
+
+import javax.annotation.PostConstruct;
+
+public class BackgroundJobServerMetricsBinder {
+
+    private final MeterRegistry registry;
+    private final BackgroundJobServer backgroundJobServer;
+
+    public BackgroundJobServerMetricsBinder(MeterRegistry registry, BackgroundJobServer backgroundJobServer) {
+        this.registry = registry;
+        this.backgroundJobServer = backgroundJobServer;
+    }
+
+    @PostConstruct
+    public void setUpMetrics() {
+        this.registryBackgroundJobServer();
+    }
+
+    private void registryBackgroundJobServer() {
+        String PREFIX = "jobrunr_background_server_";
+        String workerPoolSize = PREFIX + "worker_pool_size";
+        String pollIntervalInSeconds = PREFIX + "poll_interval_in_seconds";
+        String processAllocatedMemory = PREFIX + "process_all_located_memory";
+        String processFreeMemory = PREFIX + "process_free_memory";
+        String systemTotalMemory = PREFIX + "system_total_memory";
+        String systemFreeMemory = PREFIX + "system_free_memory";
+        String firstHeartbeat = PREFIX + "first_heartbeat";
+        String lastHeartbeat = PREFIX + "last_heartbeat";
+
+        FunctionCounter.builder(pollIntervalInSeconds, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getPollIntervalInSeconds()).tag("id", this.backgroundJobServer.getId().toString()).register(this.registry);
+        FunctionCounter.builder(workerPoolSize, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getWorkerPoolSize()).tag("id", this.backgroundJobServer.getId().toString()).register(this.registry);
+        Gauge.builder(processAllocatedMemory, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getProcessAllocatedMemory()).tag("id", this.backgroundJobServer.getId().toString()).register(this.registry);
+        Gauge.builder(processFreeMemory, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getProcessFreeMemory()).tag("id", this.backgroundJobServer.getId().toString()).register(this.registry);
+        Gauge.builder(systemFreeMemory, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getSystemFreeMemory()).tag("id", this.backgroundJobServer.getId().toString()).register(this.registry);
+        Gauge.builder(systemTotalMemory, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getSystemTotalMemory()).tag("id", this.backgroundJobServer.getId().toString()).register(this.registry);
+        Gauge.builder(firstHeartbeat, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getFirstHeartbeat().getEpochSecond()).tag("id", this.backgroundJobServer.getId().toString()).register(this.registry);
+        Gauge.builder(lastHeartbeat, this.backgroundJobServer, (bgJobServer) -> (double) bgJobServer.getServerStatus().getLastHeartbeat().getNano()).tag("id", this.backgroundJobServer.getId().toString()).register(this.registry);
+    }
+}

--- a/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/metric/StorageProviderMetricsBinder.java
+++ b/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/metric/StorageProviderMetricsBinder.java
@@ -1,21 +1,24 @@
 package org.jobrunr.metric;
 
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tags;
 import org.jobrunr.jobs.states.StateName;
-import org.jobrunr.storage.PageRequest;
+import org.jobrunr.storage.JobStats;
 import org.jobrunr.storage.StorageProvider;
+import org.jobrunr.storage.listeners.JobStatsChangeListener;
 
 import javax.annotation.PostConstruct;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
-public class StorageProviderMetricsBinder {
+public class StorageProviderMetricsBinder implements JobStatsChangeListener {
 
-    private final MeterRegistry registry;
     private final StorageProvider storageProvider;
+    private final Map<StateName, AtomicInteger> atomics = new HashMap<>();
 
-    public StorageProviderMetricsBinder(MeterRegistry registry, StorageProvider storageProvider) {
-        this.registry = registry;
+    public StorageProviderMetricsBinder(StorageProvider storageProvider) {
         this.storageProvider = storageProvider;
     }
 
@@ -27,9 +30,22 @@ public class StorageProviderMetricsBinder {
     private void registryStorageProvider() {
         String PREFIX = "jobrunr_";
         String jobs = PREFIX + "jobs";
-        Arrays.stream(StateName.values())
-                .forEach((state) -> Gauge
-                        .builder(jobs, this.storageProvider, (provider) -> (double) provider.getJobPage(state, PageRequest.ascOnUpdatedAt(0)).getTotal())
-                        .tag("state", state.toString()).register(this.registry));
+
+        Arrays.stream(StateName.values()).forEach((state) ->
+                atomics.put(state, Metrics.gauge(jobs, Tags.of("state", state.toString()), new AtomicInteger(0)))
+        );
+
+        this.storageProvider.addJobStorageOnChangeListener(this);
+    }
+
+    @Override
+    public void onChange(JobStats jobStats) {
+        atomics.get(StateName.AWAITING).set(jobStats.getAwaiting().intValue());
+        atomics.get(StateName.SCHEDULED).set(jobStats.getScheduled().intValue());
+        atomics.get(StateName.ENQUEUED).set(jobStats.getEnqueued().intValue());
+        atomics.get(StateName.PROCESSING).set(jobStats.getProcessing().intValue());
+        atomics.get(StateName.FAILED).set(jobStats.getFailed().intValue());
+        atomics.get(StateName.SUCCEEDED).set(jobStats.getSucceeded().intValue());
+        atomics.get(StateName.DELETED).set(jobStats.getDeleted().intValue());
     }
 }

--- a/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/metric/StorageProviderMetricsBinder.java
+++ b/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/metric/StorageProviderMetricsBinder.java
@@ -1,0 +1,35 @@
+package org.jobrunr.metric;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.jobrunr.jobs.states.StateName;
+import org.jobrunr.storage.PageRequest;
+import org.jobrunr.storage.StorageProvider;
+
+import javax.annotation.PostConstruct;
+import java.util.Arrays;
+
+public class StorageProviderMetricsBinder {
+
+    private final MeterRegistry registry;
+    private final StorageProvider storageProvider;
+
+    public StorageProviderMetricsBinder(MeterRegistry registry, StorageProvider storageProvider) {
+        this.registry = registry;
+        this.storageProvider = storageProvider;
+    }
+
+    @PostConstruct
+    public void setUpMetrics() {
+        this.registryStorageProvider();
+    }
+
+    private void registryStorageProvider() {
+        String PREFIX = "jobrunr_";
+        String jobs = PREFIX + "jobs";
+        Arrays.stream(StateName.values())
+                .forEach((state) -> Gauge
+                        .builder(jobs, this.storageProvider, (provider) -> (double) provider.getJobPage(state, PageRequest.ascOnUpdatedAt(0)).getTotal())
+                        .tag("state", state.toString()).register(this.registry));
+    }
+}

--- a/jobrunr-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/jobrunr-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -3,4 +3,5 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.jobrunr.autoc
   org.jobrunr.autoconfigure.storage.JobRunrJedisStorageAutoConfiguration,\
   org.jobrunr.autoconfigure.storage.JobRunrLettuceStorageAutoConfiguration,\
   org.jobrunr.autoconfigure.storage.JobRunrMongoDBStorageAutoConfiguration,\
-  org.jobrunr.autoconfigure.storage.JobRunrSqlStorageAutoConfiguration
+  org.jobrunr.autoconfigure.storage.JobRunrSqlStorageAutoConfiguration, \
+  org.jobrunr.autoconfigure.metric.JobRunrMetricsAutoConfiguration

--- a/jobrunr-spring-boot-starter/src/test/java/org/jobrunr/autoconfigure/metric/JobRunrMetricsAutoConfigurationTest.java
+++ b/jobrunr-spring-boot-starter/src/test/java/org/jobrunr/autoconfigure/metric/JobRunrMetricsAutoConfigurationTest.java
@@ -1,0 +1,46 @@
+package org.jobrunr.autoconfigure.metric;
+
+
+import io.micrometer.core.instrument.Metrics;
+import org.jobrunr.autoconfigure.JobRunrAutoConfiguration;
+import org.jobrunr.autoconfigure.storage.JobRunrSqlStorageAutoConfiguration;
+import org.jobrunr.metric.BackgroundJobServerMetricsBinder;
+import org.jobrunr.metric.StorageProviderMetricsBinder;
+import org.jobrunr.storage.InMemoryStorageProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JobRunrMetricsAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    JobRunrAutoConfiguration.class,
+                    JobRunrSqlStorageAutoConfiguration.class,
+                    JobRunrMetricsAutoConfiguration.class
+            ));
+
+    @Test
+    void storageProviderMetricsIsIgnoredIfLibraryIsNotPresent() {
+        this.contextRunner
+                .withClassLoader(new FilteredClassLoader(Metrics.class))
+                .withUserConfiguration(InMemoryStorageProvider.class)
+                .run((context) -> {
+                    assertThat(context).doesNotHaveBean(StorageProviderMetricsBinder.class);
+                    assertThat(context).doesNotHaveBean(BackgroundJobServerMetricsBinder.class);
+                });
+    }
+
+    @Test
+    void metricsBinderIsIgnoredIfBackgroundJobServerIsNotPresent() {
+        this.contextRunner
+                .withUserConfiguration(InMemoryStorageProvider.class)
+                .run((context) -> {
+                    assertThat(context).hasSingleBean(StorageProviderMetricsBinder.class);
+                    assertThat(context).doesNotHaveBean(BackgroundJobServerMetricsBinder.class);
+                });
+    }
+}


### PR DESCRIPTION
I propose to export some metrics, like jobs counter, background job server status, etc. 
So jobrunr can be monitor on popular third-party application monitoring systems, such as Prometheus, Datadog, New Relic, WaveFront, dynaTrace, etc.