### PR TITLE
Make `scheduleRecurrently` public

### DIFF
--- a/core/src/main/java/org/jobrunr/scheduling/JobScheduler.java
+++ b/core/src/main/java/org/jobrunr/scheduling/JobScheduler.java
@@ -591,7 +591,7 @@ public class JobScheduler {
         return saveJob(new Job(id, jobDetails, new ScheduledState(scheduleAt)));
     }
 
-    String scheduleRecurrently(String id, JobDetails jobDetails, CronExpression cronExpression, ZoneId zoneId) {
+    public String scheduleRecurrently(String id, JobDetails jobDetails, CronExpression cronExpression, ZoneId zoneId) {
         final RecurringJob recurringJob = new RecurringJob(id, jobDetails, cronExpression, zoneId);
         jobFilterUtils.runOnCreatingFilter(recurringJob);
         RecurringJob savedRecurringJob = this.storageProvider.saveRecurringJob(recurringJob);


### PR DESCRIPTION
The `JobDetails` constructor is already public and sometimes it's easier to create an instance of it than a lambda (for example when using reflection/annotations)