### PR TITLE
Support using a non-default datasource

### DIFF
--- a/framework-support/jobrunr-micronaut-feature/src/main/java/org/jobrunr/micronaut/autoconfigure/JobRunrConfiguration.java
+++ b/framework-support/jobrunr-micronaut-feature/src/main/java/org/jobrunr/micronaut/autoconfigure/JobRunrConfiguration.java
@@ -38,6 +38,11 @@ public interface JobRunrConfiguration {
          * Allows to set the table prefix used by JobRunr
          */
         Optional<String> getTablePrefix();
+
+        /**
+         * An optional named datasource to use. Defaults to the 'default' datasource.
+         */
+        Optional<String> getDatasource();
     }
 
     @ConfigurationProperties("jobScheduler")

--- a/framework-support/jobrunr-micronaut-feature/src/main/java/org/jobrunr/micronaut/autoconfigure/JobRunrFactory.java
+++ b/framework-support/jobrunr-micronaut-feature/src/main/java/org/jobrunr/micronaut/autoconfigure/JobRunrFactory.java
@@ -25,6 +25,7 @@ import org.jobrunr.utils.mapper.JsonMapper;
 import org.jobrunr.utils.mapper.jackson.JacksonJsonMapper;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.sql.DataSource;
 
@@ -111,7 +112,7 @@ public class JobRunrFactory {
     @Singleton
     @Primary
     @Requires(beans = {DataSource.class})
-    public StorageProvider sqlStorageProvider(DataSource dataSource, JobMapper jobMapper) {
+    public StorageProvider sqlStorageProvider(@Named("${jobrunr.database.datasource:default}") DataSource dataSource, JobMapper jobMapper) {
         String tablePrefix = configuration.getDatabase().getTablePrefix().orElse(null);
         DefaultSqlStorageProvider.DatabaseOptions databaseOptions = configuration.getDatabase().isSkipCreate() ? DefaultSqlStorageProvider.DatabaseOptions.SKIP_CREATE : DefaultSqlStorageProvider.DatabaseOptions.CREATE;
         StorageProvider storageProvider = SqlStorageProviderFactory.using(dataSource, tablePrefix, databaseOptions);


### PR DESCRIPTION
Use alternative DataSource for jobrunr in a micronaut service.

  - add `jobrunr.database.datasource` field to `JobRunrConfiguration`
  - add `Named` qualifier to `DataSource` in `JobRunrFactory`

In the Micronaut service's `application.yml`:
```
datasources:
  jobrunr:
    url: jdbc:postgresql://localhost/jobrunr
    username: jobrunr
    password: ...
    driver-class-name: org.postgresql.Driver
    schema: jobrunr
...
jobrunr:
  job-scheduler:
    enabled: true
  background-job-server:
    enabled: true
  dashboard:
    enabled: true
  database:
    skip-create: false
    datasource: jobrunr
```

Tested with example-jobrunr-micronaut:

  - no datasource: uses in-memory store
  - default datasource, jobrunr.database.datasource not defined: uses
    default datasource.
  - default datasource, jobrunr.database.datasource defined: uses
    defined datasource (e.g., jobrunr)