### PR TITLE
add UTF-8 to OutputStreamWriter

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -73,14 +73,14 @@ steps:
       - name: reports
         path: /tmp/reports
 
-  - name: slack
-    image: plugins/slack
-    settings:
-      webhook:
-        from_secret: SLACK_WEBHOOK
-      channel: drone
-    when:
-      status: [ success, failure ]
+#  - name: slack
+#    image: plugins/slack
+#    settings:
+#      webhook:
+#        from_secret: SLACK_WEBHOOK
+#      channel: drone
+#    when:
+#      status: [ success, failure ]
 
 volumes:
   - name: dockersock
@@ -202,14 +202,14 @@ steps:
       - git commit -m "Update readme to version ${DRONE_TAG} [CI SKIP]"
       - git push https://$(GITHUB_PAT)@github.com/jobrunr/jobrunr.git
 
-  - name: slack
-    image: plugins/slack
-    settings:
-      webhook:
-        from_secret: SLACK_WEBHOOK
-      channel: drone
-    when:
-      status: [ success, failure ]
+#  - name: slack
+#    image: plugins/slack
+#    settings:
+#      webhook:
+#        from_secret: SLACK_WEBHOOK
+#      channel: drone
+#    when:
+#      status: [ success, failure ]
 
 volumes:
   - name: dockersock

--- a/core/src/main/java/org/jobrunr/dashboard/server/sse/SseExchange.java
+++ b/core/src/main/java/org/jobrunr/dashboard/server/sse/SseExchange.java
@@ -6,6 +6,7 @@ import com.sun.net.httpserver.HttpExchange;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 
 public class SseExchange implements AutoCloseable {
 
@@ -14,7 +15,7 @@ public class SseExchange implements AutoCloseable {
     private boolean closed;
 
     public SseExchange(HttpExchange httpExchange) throws IOException {
-        this.writer = new BufferedWriter(new OutputStreamWriter(httpExchange.getResponseBody()));
+        this.writer = new BufferedWriter(new OutputStreamWriter(httpExchange.getResponseBody(), StandardCharsets.UTF_8));
         Headers responseHeaders = httpExchange.getResponseHeaders();
         responseHeaders.add("Cache-Control", "no-cache,public");
         responseHeaders.add("Content-Type", "text/event-stream");


### PR DESCRIPTION
resolved #325 

UTF-8 was added to OutputStreamWriter to correct the issue of breaking Korean when calling `/sse`.
After modifying it, I confirmed that Korean came out well in my project.

