### PR TITLE
add static method for creating AmazonDocumentDBStorageProvider as a default settings

### DIFF
--- a/core/src/main/java/org/jobrunr/storage/nosql/documentdb/AmazonDocumentDBStorageProvider.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/documentdb/AmazonDocumentDBStorageProvider.java
@@ -1,9 +1,19 @@
 package org.jobrunr.storage.nosql.documentdb;
 
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.bson.UuidRepresentation;
+import org.bson.codecs.UuidCodec;
+import org.bson.codecs.configuration.CodecRegistries;
 import org.jobrunr.storage.StorageProviderUtils.DatabaseOptions;
 import org.jobrunr.storage.nosql.mongo.MongoDBStorageProvider;
 import org.jobrunr.utils.resilience.RateLimiter;
+
+import static com.mongodb.ReadPreference.secondaryPreferred;
+import static java.util.Collections.singletonList;
 
 public class AmazonDocumentDBStorageProvider extends MongoDBStorageProvider {
 
@@ -41,5 +51,23 @@ public class AmazonDocumentDBStorageProvider extends MongoDBStorageProvider {
 
     public AmazonDocumentDBStorageProvider(MongoClient mongoClient, String dbName, String collectionPrefix, DatabaseOptions databaseOptions, RateLimiter changeListenerNotificationRateLimit) {
         super(mongoClient, dbName, collectionPrefix, databaseOptions, changeListenerNotificationRateLimit);
+    }
+
+    public static AmazonDocumentDBStorageProvider amazonDocumentDBStorageProviderWithDefaultSetting(String hostName, int port, MongoCredential credential) {
+        return new AmazonDocumentDBStorageProvider(getDocumentDBDefaultSetting(new ServerAddress(hostName, port), credential));
+    }
+
+    private static MongoClient getDocumentDBDefaultSetting(ServerAddress serverAddress, MongoCredential credential) {
+        return MongoClients.create(
+                MongoClientSettings.builder()
+                        .applyToClusterSettings(builder -> builder.hosts(singletonList(serverAddress)))
+                        .credential(credential)
+                        .codecRegistry(CodecRegistries.fromRegistries(
+                                CodecRegistries.fromCodecs(new UuidCodec(UuidRepresentation.STANDARD)),
+                                MongoClientSettings.getDefaultCodecRegistry()
+                        ))
+                        .retryWrites(false)
+                        .readPreference(secondaryPreferred())
+                        .build());
     }
 }


### PR DESCRIPTION
Hello
I'm using the AmazonDocumentDBStorageProvider from jobrunr. 
There was an improvement during use, so I sent a PR.

There are several differences between DocumentDB and MongoDB, but MongoClient has the default value of MongoDB. Therefore, I added the DocumentDB default value to the AmazonDocumentDBStorageProvider.

1. RetryWrites is not supported, so I changed it to false. ([ref](https://docs.aws.amazon.com/documentdb/latest/developerguide/functional-differences.html#functional-differences.retryable-writes))
2. For readPreference, secondaryPreference is the default, and DocumentDB recommends this value. (Primary is the default in MongoDB) ([ref](https://docs.aws.amazon.com/documentdb/latest/developerguide/connect-to-replica-set.html))

MongoClient can be customized and used directly, but it was thought that it would be cumbersome for users to find out. I added `getDocumentDBDefaultSetting()` method to get preferences.

Thank you