### PR TITLE
Allow @Recurring jobs access to JobContext

### DIFF
--- a/framework-support/jobrunr-micronaut-feature/src/main/java/org/jobrunr/micronaut/annotations/Recurring.java
+++ b/framework-support/jobrunr-micronaut-feature/src/main/java/org/jobrunr/micronaut/annotations/Recurring.java
@@ -7,7 +7,7 @@ import java.lang.annotation.*;
 /**
  * Allows to recurrently schedule a method from a Micronaut Service bean using JobRunr.
  *
- * <em>Note that methods annotated with the &commat;Recurring annotation may not have any parameters.</em>
+ * <em>Note that methods annotated with the &commat;Recurring annotation may only have zero parameters or a single parameter of type org.jobrunr.jobs.context.JobContext.</em>
  *
  * <h5>An example:</h5>
  * <pre>

--- a/framework-support/jobrunr-micronaut-feature/src/main/java/org/jobrunr/scheduling/JobRunrRecurringJobScheduler.java
+++ b/framework-support/jobrunr-micronaut-feature/src/main/java/org/jobrunr/scheduling/JobRunrRecurringJobScheduler.java
@@ -2,11 +2,13 @@ package org.jobrunr.scheduling;
 
 import io.micronaut.inject.ExecutableMethod;
 import org.jobrunr.jobs.JobDetails;
+import org.jobrunr.jobs.context.JobContext;
 import org.jobrunr.micronaut.annotations.Recurring;
 import org.jobrunr.scheduling.cron.CronExpression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Method;
 import java.time.ZoneId;
 
 import static java.util.Collections.emptyList;
@@ -22,8 +24,9 @@ public class JobRunrRecurringJobScheduler {
     }
 
     public void schedule(ExecutableMethod<?, ?> method) {
-        if (method.getTargetMethod().getParameterCount() > 0) {
-            throw new IllegalStateException("Methods annotated with " + Recurring.class.getName() + " can not have parameters.");
+        Method call =  method.getTargetMethod();
+        if (call.getParameterCount() > 0 && !(call.getParameterCount() == 1 && JobContext.class.isAssignableFrom(call.getParameterTypes()[0]))) {
+            throw new IllegalStateException("Methods annotated with " + Recurring.class.getName() + " can only have zero parameters or a single parameter of type JobContext.");
         }
 
         String id = getId(method);

--- a/framework-support/jobrunr-quarkus-extension/deployment/src/main/java/org/jobrunr/quarkus/extension/deployment/RecurringJobsFinder.java
+++ b/framework-support/jobrunr-quarkus-extension/deployment/src/main/java/org/jobrunr/quarkus/extension/deployment/RecurringJobsFinder.java
@@ -8,6 +8,7 @@ import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 import org.jobrunr.jobs.JobDetails;
+import org.jobrunr.jobs.context.JobContext;
 import org.jobrunr.quarkus.annotations.Recurring;
 import org.jobrunr.scheduling.JobRunrRecurringJobRecorder;
 
@@ -66,8 +67,8 @@ public class RecurringJobsFinder {
 
     private JobDetails getJobDetails(AnnotationInstance recurringJobAnnotation) {
         final MethodInfo methodInfo = recurringJobAnnotation.target().asMethod();
-        if (!methodInfo.parameters().isEmpty()) {
-            throw new IllegalStateException("Methods annotated with " + Recurring.class.getName() + " can not have parameters.");
+        if (methodInfo.parameters().size() > 0 && !(methodInfo.parameters().size() == 1 && JobContext.class.isAssignableFrom(methodInfo.parameters().get(0).getClass()))) {
+            throw new IllegalStateException("Methods annotated with " + Recurring.class.getName() + " can only have zero parameters or a single parameter of type JobContext.");
         }
         final JobDetails jobDetails = new JobDetails(methodInfo.declaringClass().name().toString(), null, methodInfo.name(), new ArrayList<>());
         jobDetails.setCacheable(true);

--- a/framework-support/jobrunr-quarkus-extension/runtime/src/main/java/org/jobrunr/quarkus/annotations/Recurring.java
+++ b/framework-support/jobrunr-quarkus-extension/runtime/src/main/java/org/jobrunr/quarkus/annotations/Recurring.java
@@ -5,7 +5,7 @@ import java.lang.annotation.*;
 /**
  * Allows to recurrently schedule a method from a Quarkus bean using JobRunr.
  *
- * <em>Note that methods annotated with the &commat;Recurring annotation may not have any parameters.</em>
+ * <em>Note that methods annotated with the &commat;Recurring annotation may only have zero parameters or a single parameter of type org.jobrunr.jobs.context.JobContext.</em>
  *
  * <h5>An example:</h5>
  * <pre>

--- a/framework-support/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/scheduling/RecurringJobPostProcessor.java
+++ b/framework-support/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/scheduling/RecurringJobPostProcessor.java
@@ -3,6 +3,7 @@ package org.jobrunr.scheduling;
 import org.jobrunr.jobs.JobDetails;
 import org.jobrunr.scheduling.cron.CronExpression;
 import org.jobrunr.spring.annotations.Recurring;
+import org.jobrunr.jobs.context.JobContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -61,8 +62,8 @@ public class RecurringJobPostProcessor implements BeanPostProcessor, EmbeddedVal
             if (!method.isAnnotationPresent(Recurring.class)) {
                 return;
             }
-            if (method.getParameterCount() > 0) {
-                throw new IllegalStateException("Methods annotated with " + Recurring.class.getName() + " can not have parameters.");
+            if (method.getParameterCount() > 0 && !(method.getParameterCount() == 1 && JobContext.class.isAssignableFrom(method.getParameterTypes()[0]))) {
+                throw new IllegalStateException("Methods annotated with " + Recurring.class.getName() + " can only have zero parameters or a single parameter of type JobContext.");
             }
 
             final Recurring recurringAnnotation = method.getAnnotation(Recurring.class);

--- a/framework-support/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/spring/annotations/Recurring.java
+++ b/framework-support/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/spring/annotations/Recurring.java
@@ -5,7 +5,7 @@ import java.lang.annotation.*;
 /**
  * Allows to recurrently schedule a method from a Spring Service bean using JobRunr.
  *
- * <em>Note that methods annotated with the &commat;Recurring annotation may not have any parameters.</em>
+ * <em>Note that methods annotated with the &commat;Recurring annotation may only have zero parameters or a single parameter of type org.jobrunr.jobs.context.JobContext.</em>
  *
  * <h5>An example:</h5>
  * <pre>


### PR DESCRIPTION
Per the [discussion](https://github.com/jobrunr/jobrunr/discussions/409) on the topic -  the micronaught, quarkus, and spring-boot integrations have been updated to allow methods with the `@Recurring` annotation to have zero parameters or a single parameter of type `org.jobrunr.jobs.context.JobContext`.