### PR TITLE
Update JavaDoc and Error Messages for @Recurring Jobs

### DIFF
--- a/framework-support/jobrunr-micronaut-feature/src/main/java/org/jobrunr/micronaut/annotations/Recurring.java
+++ b/framework-support/jobrunr-micronaut-feature/src/main/java/org/jobrunr/micronaut/annotations/Recurring.java
@@ -7,7 +7,7 @@ import java.lang.annotation.*;
 /**
  * Allows to recurrently schedule a method from a Micronaut Service bean using JobRunr.
  *
- * <em>Note that methods annotated with the &commat;Recurring annotation may not have any parameters.</em>
+ * <em>Note that methods annotated with the &commat;Recurring annotation may only have zero parameters or a single parameter of type org.jobrunr.jobs.context.JobContext.</em>
  *
  * <h5>An example:</h5>
  * <pre>

--- a/framework-support/jobrunr-micronaut-feature/src/main/java/org/jobrunr/scheduling/JobRunrRecurringJobScheduler.java
+++ b/framework-support/jobrunr-micronaut-feature/src/main/java/org/jobrunr/scheduling/JobRunrRecurringJobScheduler.java
@@ -25,7 +25,7 @@ public class JobRunrRecurringJobScheduler {
 
     public void schedule(ExecutableMethod<?, ?> method) {
         if (hasParametersOutsideOfJobContext(method.getTargetMethod())) {
-            throw new IllegalStateException("Methods annotated with " + Recurring.class.getName() + " can not have parameters.");
+            throw new IllegalStateException("Methods annotated with " + Recurring.class.getName() + " can only have zero parameters or a single parameter of type JobContext.");
         }
 
         String id = getId(method);

--- a/framework-support/jobrunr-quarkus-extension/deployment/src/main/java/org/jobrunr/quarkus/extension/deployment/RecurringJobsFinder.java
+++ b/framework-support/jobrunr-quarkus-extension/deployment/src/main/java/org/jobrunr/quarkus/extension/deployment/RecurringJobsFinder.java
@@ -69,7 +69,7 @@ public class RecurringJobsFinder {
     private JobDetails getJobDetails(AnnotationInstance recurringJobAnnotation) {
         final MethodInfo methodInfo = recurringJobAnnotation.target().asMethod();
         if (hasParametersOutsideOfJobContext(methodInfo)) {
-            throw new IllegalStateException("Methods annotated with " + Recurring.class.getName() + " can not have parameters.");
+            throw new IllegalStateException("Methods annotated with " + Recurring.class.getName() + " can only have zero parameters or a single parameter of type JobContext.");
         }
         final JobDetails jobDetails = new JobDetails(methodInfo.declaringClass().name().toString(), null, methodInfo.name(), new ArrayList<>());
         jobDetails.setCacheable(true);

--- a/framework-support/jobrunr-quarkus-extension/runtime/src/main/java/org/jobrunr/quarkus/annotations/Recurring.java
+++ b/framework-support/jobrunr-quarkus-extension/runtime/src/main/java/org/jobrunr/quarkus/annotations/Recurring.java
@@ -5,7 +5,7 @@ import java.lang.annotation.*;
 /**
  * Allows to recurrently schedule a method from a Quarkus bean using JobRunr.
  *
- * <em>Note that methods annotated with the &commat;Recurring annotation may not have any parameters.</em>
+ * <em>Note that methods annotated with the &commat;Recurring annotation may only have zero parameters or a single parameter of type org.jobrunr.jobs.context.JobContext.</em>
  *
  * <h5>An example:</h5>
  * <pre>

--- a/framework-support/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/scheduling/RecurringJobPostProcessor.java
+++ b/framework-support/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/scheduling/RecurringJobPostProcessor.java
@@ -63,7 +63,7 @@ public class RecurringJobPostProcessor implements BeanPostProcessor, EmbeddedVal
                 return;
             }
             if (hasParametersOutsideOfJobContext(method)) {
-                throw new IllegalStateException("Methods annotated with " + Recurring.class.getName() + " can not have parameters.");
+                throw new IllegalStateException("Methods annotated with " + Recurring.class.getName() + " can only have zero parameters or a single parameter of type JobContext.");
             }
 
             final Recurring recurringAnnotation = method.getAnnotation(Recurring.class);

--- a/framework-support/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/spring/annotations/Recurring.java
+++ b/framework-support/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/spring/annotations/Recurring.java
@@ -5,7 +5,7 @@ import java.lang.annotation.*;
 /**
  * Allows to recurrently schedule a method from a Spring Service bean using JobRunr.
  *
- * <em>Note that methods annotated with the &commat;Recurring annotation may not have any parameters.</em>
+ * <em>Note that methods annotated with the &commat;Recurring annotation may only have zero parameters or a single parameter of type org.jobrunr.jobs.context.JobContext.</em>
  *
  * <h5>An example:</h5>
  * <pre>

--- a/framework-support/jobrunr-spring-boot-starter/src/test/java/org/jobrunr/scheduling/RecurringJobPostProcessorTest.java
+++ b/framework-support/jobrunr-spring-boot-starter/src/test/java/org/jobrunr/scheduling/RecurringJobPostProcessorTest.java
@@ -131,7 +131,7 @@ class RecurringJobPostProcessorTest {
 
         assertThatThrownBy(() -> recurringJobPostProcessor.postProcessAfterInitialization(new MyUnsupportedService(), "not important"))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Methods annotated with " + Recurring.class.getName() + " can not have parameters.");
+                .hasMessage("Methods annotated with " + Recurring.class.getName() + " can only have zero parameters or a single parameter of type JobContext.");
     }
 
     public static class MyServiceWithoutRecurringAnnotation {


### PR DESCRIPTION
Update JavaDoc and error message for @Recurring jobs to allow zero parameters or a single parameter of type JobContext per https://github.com/jobrunr/jobrunr/discussions/409

@rdehuyss looks like you beat me to creating the PR - thanks!  I thought updating the documentation and error message would be a good idea. 