### PR TITLE
Clarify "JobRunr only supports enqueueing/scheduling of one method" error message

### DIFF
--- a/core/src/main/java/org/jobrunr/jobs/details/instructions/JobDetailsInstruction.java
+++ b/core/src/main/java/org/jobrunr/jobs/details/instructions/JobDetailsInstruction.java
@@ -29,7 +29,7 @@ public class JobDetailsInstruction extends VisitMethodInstruction {
     @Override
     public Object invokeInstruction() {
         if (!isLastInstruction() && isVoidInstruction()) {
-            throw new JobRunrException("JobRunr only supports enqueueing/scheduling of one method");
+            throw new JobRunrException("JobRunr only supports enqueueing/scheduling of one void method (which also must be the last statement executed)");
         } else if (isLastInstruction()) {
             jobDetailsBuilder.setClassName(getClassName());
             jobDetailsBuilder.setMethodName(getMethodName());


### PR DESCRIPTION
I've unfortunately just spent upwards of an hour trying to figure out why 1 of my jobs started failing after adding in `LOGGER.INFO(...)` statements within the job.

The error message **JobRunr only supports enqueueing/scheduling of one method** makes it sound as though you can only have one method invocation.

This is not true.

For example, this is completely valid with 4 method invocations:

```java
jobScheduler.enqueue(() -> {
    final String a = serviceA.call();
    final String b = serviceB.call();
    final String c = serviceC.call();

    serviceD.doSomething(a, b, c);
});
```

What the error actually means is that, this is invalid - a void invocation which is not the last statement:

```java
jobScheduler.enqueue(() -> {
    serviceA.voidMethod()
    final String a = serviceA.call();
});
```

And this is also invalid - 2 void invocations:

```java
jobScheduler.enqueue(() -> {
    serviceA.voidMethod()
    serviceB.voidMethod()
});
```

I've updated the exception message to be much clearer regarding this expectation as currently, as it stands, it can be quite ambiguous & misleading.

I'd appreciate any and all feedback, thank you in advance.

EE

P.S. the wording on this [documentation page](https://www.jobrunr.io/en/documentation/background-methods/) ("Only one method to enqueue is supported") could also do with being updated to reflex the above i.e. something like "Only one void method to enqueue is supported (as the last statement)". I haven't dug into how/if I can update that but happy to do so as part of this MR if the docs are in this codebase.  