### PR TITLE
Fix Micronaut Data `No current transaction present. Consider declaring @Transactional on the surrounding method` error

### DIFF
--- a/framework-support/jobrunr-micronaut-feature/build.gradle
+++ b/framework-support/jobrunr-micronaut-feature/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     compileOnly 'org.mongodb:mongodb-driver-sync'
     compileOnly 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
     compileOnly 'io.micrometer:micrometer-core'
+    compileOnly 'io.micronaut.data:micronaut-data-tx'
 
     testImplementation testFixtures(project(":core"))
     testImplementation 'io.micronaut.test:micronaut-test-junit5'

--- a/framework-support/jobrunr-micronaut-feature/src/main/java/org/jobrunr/micronaut/autoconfigure/storage/JobRunrSqlStorageProviderFactory.java
+++ b/framework-support/jobrunr-micronaut-feature/src/main/java/org/jobrunr/micronaut/autoconfigure/storage/JobRunrSqlStorageProviderFactory.java
@@ -5,6 +5,7 @@ import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.transaction.jdbc.DelegatingDataSource;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.jobrunr.jobs.mappers.JobMapper;
@@ -28,6 +29,9 @@ public class JobRunrSqlStorageProviderFactory {
         DataSource dataSource = configuration.getDatabase().getDatasource()
                 .map(datasourceName -> beanContext.getBean(DataSource.class, Qualifiers.byName(datasourceName)))
                 .orElseGet(() -> beanContext.getBean(DataSource.class));
+        if (dataSource instanceof DelegatingDataSource) {
+            dataSource = ((DelegatingDataSource) dataSource).getTargetDataSource();
+        }
         String tablePrefix = configuration.getDatabase().getTablePrefix().orElse(null);
         StorageProviderUtils.DatabaseOptions databaseOptions = configuration.getDatabase().isSkipCreate() ? StorageProviderUtils.DatabaseOptions.SKIP_CREATE : StorageProviderUtils.DatabaseOptions.CREATE;
         StorageProvider storageProvider = org.jobrunr.storage.sql.common.SqlStorageProviderFactory.using(dataSource, tablePrefix, databaseOptions);


### PR DESCRIPTION
Explained here: https://stackoverflow.com/a/71933329/727768. Needed to unwrap the TransactionalAwareDataSource to its original one. I'm using a temporary solution that just replaces the existing `JobRunrSqlStorageProviderFactory`:

```kotlin
@Factory
@Requires(beans = [DataSource::class])
@Requires(property = "jobrunr.database.type", value = "sql", defaultValue = "sql")
@Replaces(factory = org.jobrunr.micronaut.autoconfigure.storage.JobRunrSqlStorageProviderFactory::class)
class JobRunrSqlStorageProviderFactory {

    @Inject
    private lateinit var configuration: JobRunrConfiguration

    @Singleton
    fun sqlStorageProvider(beanContext: BeanContext, jobMapper: JobMapper): StorageProvider {
        val dataSource = configuration.database.datasource
            .map { datasourceName: String? ->
                beanContext.getBean(
                    DataSource::class.java,
                    Qualifiers.byName(datasourceName)
                )
            }
            .orElseGet { beanContext.getBean(DataSource::class.java) }

        val unwrappedDataSource = (dataSource as DelegatingDataSource).targetDataSource

        val tablePrefix = configuration.database.tablePrefix.orElse(null)
        val databaseOptions = if (configuration.database.isSkipCreate) DatabaseOptions.SKIP_CREATE else DatabaseOptions.CREATE
        val storageProvider = SqlStorageProviderFactory.using(unwrappedDataSource, tablePrefix, databaseOptions)
        storageProvider.setJobMapper(jobMapper)
        return storageProvider
    }
}
```