### PR TITLE
BackgroundJobPerformerFactory implementation - Fixes #483

### DIFF
--- a/core/src/main/java/org/jobrunr/server/BackgroundJobPerformer.java
+++ b/core/src/main/java/org/jobrunr/server/BackgroundJobPerformer.java
@@ -38,11 +38,7 @@ public class BackgroundJobPerformer implements Runnable {
     public void run() {
         try {
             backgroundJobServer.getJobZooKeeper().notifyThreadOccupied();
-            boolean canProcess = updateJobStateToProcessingRunJobFiltersAndReturnIfProcessingCanStart();
-            if (canProcess) {
-                runActualJob();
-                updateJobStateToSucceededAndRunJobFilters();
-            }
+            performJob();
         } catch (Exception e) {
             if (isJobDeletedWhileProcessing(e)) {
                 // nothing to do anymore as Job is deleted
@@ -57,6 +53,14 @@ public class BackgroundJobPerformer implements Runnable {
             }
         } finally {
             backgroundJobServer.getJobZooKeeper().notifyThreadIdle();
+        }
+    }
+
+    protected void performJob() throws Exception {
+        boolean canProcess = updateJobStateToProcessingRunJobFiltersAndReturnIfProcessingCanStart();
+        if (canProcess) {
+            runActualJob();
+            updateJobStateToSucceededAndRunJobFilters();
         }
     }
 

--- a/core/src/main/java/org/jobrunr/server/BackgroundJobPerformerFactory.java
+++ b/core/src/main/java/org/jobrunr/server/BackgroundJobPerformerFactory.java
@@ -1,0 +1,11 @@
+package org.jobrunr.server;
+
+import org.jobrunr.jobs.Job;
+
+public interface BackgroundJobPerformerFactory {
+
+    int getPriority();
+
+    BackgroundJobPerformer newBackgroundJobPerformer(BackgroundJobServer backgroundJobServer, Job job);
+
+}

--- a/core/src/main/java/org/jobrunr/server/BackgroundJobServer.java
+++ b/core/src/main/java/org/jobrunr/server/BackgroundJobServer.java
@@ -85,8 +85,8 @@ public class BackgroundJobServer implements BackgroundJobServerMBean {
         this.workDistributionStrategy = createWorkDistributionStrategy(configuration);
         this.serverZooKeeper = createServerZooKeeper();
         this.jobZooKeeper = createJobZooKeeper();
-        this.lifecycleLock = new BackgroundJobServerLifecycleLock();
         this.backgroundJobPerformerFactory = loadBackgroundJobPerformerFactory();
+        this.lifecycleLock = new BackgroundJobServerLifecycleLock();
     }
 
     public UUID getId() {

--- a/core/src/main/java/org/jobrunr/server/jmx/JobServerStats.java
+++ b/core/src/main/java/org/jobrunr/server/jmx/JobServerStats.java
@@ -15,7 +15,7 @@ public class JobServerStats {
     private final ConcurrentMap<String, Object> cachedValues = new ConcurrentHashMap<>();
 
     public JobServerStats() {
-        this(ManagementFactory.getOperatingSystemMXBean(), ManagementFactory.getPlatformMBeanServer());
+        this(getOperatingSystemMXBean(), getPlatformMBeanServer());
     }
 
     protected JobServerStats(OperatingSystemMXBean operatingSystemMXBean, MBeanServer platformMBeanServer) {
@@ -69,12 +69,30 @@ public class JobServerStats {
 
     // visible for testing
     // see bug JDK-8193878
+
     <O> O getMXBeanValue(String name) {
+        if(platformMBeanServer == null || operatingSystemMXBean == null) return cast(-1);
+
         try {
             final Object attribute = platformMBeanServer.getAttribute(operatingSystemMXBean.getObjectName(), name);
             return cast(attribute);
         } catch (Throwable ex) {
             return cast(-1);
+        }
+    }
+    private static OperatingSystemMXBean getOperatingSystemMXBean() {
+        try {
+            return ManagementFactory.getOperatingSystemMXBean();
+        } catch (ExceptionInInitializerError | NoClassDefFoundError e) {
+            return null;
+        }
+    }
+
+    private static MBeanServer getPlatformMBeanServer() {
+        try {
+            return ManagementFactory.getPlatformMBeanServer();
+        } catch (ExceptionInInitializerError | NoClassDefFoundError e) {
+            return null;
         }
     }
 }

--- a/core/src/test/java/org/jobrunr/server/BackgroundJobServerTest.java
+++ b/core/src/test/java/org/jobrunr/server/BackgroundJobServerTest.java
@@ -6,7 +6,6 @@ import ch.qos.logback.core.read.ListAppender;
 import org.jobrunr.JobRunrException;
 import org.jobrunr.configuration.JobRunr;
 import org.jobrunr.jobs.Job;
-import org.jobrunr.jobs.JobDetails;
 import org.jobrunr.jobs.JobId;
 import org.jobrunr.jobs.lambdas.IocJobLambda;
 import org.jobrunr.jobs.states.ProcessingState;
@@ -15,7 +14,6 @@ import org.jobrunr.scheduling.BackgroundJob;
 import org.jobrunr.server.runner.BackgroundJobWithIocRunner;
 import org.jobrunr.server.runner.BackgroundJobWithoutIocRunner;
 import org.jobrunr.server.runner.BackgroundStaticJobWithoutIocRunner;
-import org.jobrunr.server.threadpool.JobRunrExecutor;
 import org.jobrunr.storage.InMemoryStorageProvider;
 import org.jobrunr.storage.StorageException;
 import org.jobrunr.storage.StorageProvider;
@@ -24,18 +22,15 @@ import org.jobrunr.stubs.TestService;
 import org.jobrunr.stubs.TestServiceForIoC;
 import org.jobrunr.stubs.TestServiceThatCannotBeRun;
 import org.jobrunr.utils.SleepUtils;
-import org.jobrunr.utils.mapper.JsonMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.internal.stubbing.answers.AnswersWithDelay;
 import org.mockito.internal.stubbing.answers.ThrowsException;
 
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -53,12 +48,7 @@ import static org.jobrunr.jobs.JobTestBuilder.anEnqueuedJob;
 import static org.jobrunr.jobs.states.StateName.*;
 import static org.jobrunr.server.BackgroundJobServerConfiguration.usingStandardBackgroundJobServerConfiguration;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 class BackgroundJobServerTest {
 
@@ -70,7 +60,7 @@ class BackgroundJobServerTest {
     private ListAppender<ILoggingEvent> logger;
 
     @BeforeEach
-    void setUpTestService() {
+    void setUp() {
         testService = new TestService();
         testServiceForIoC = new TestServiceForIoC("an argument");
         testService.reset();
@@ -356,86 +346,6 @@ class BackgroundJobServerTest {
 
         await().atMost(10, SECONDS)
                 .untilAsserted(() -> assertThat(logger).hasErrorMessage("JobRunr BackgroundJobServer failed to start"));
-    }
-
-    @Test
-    void testProcessJobUsesBackgroundJobPerformerFactoryWithMaximumPriorityWhenAvailable() {
-        try (MockedStatic<ServiceLoader> serviceLoaderMock = Mockito.mockStatic(ServiceLoader.class)) {
-
-            // arrange
-            JobRunrExecutor jobRunrExecutor = mock(JobRunrExecutor.class);
-            ServiceLoader<JobRunrExecutor> jobRunrExecutorServiceLoader = mock(ServiceLoader.class);
-            when(jobRunrExecutorServiceLoader.iterator()).thenReturn(Stream.of(jobRunrExecutor).iterator());
-
-            BackgroundJobPerformer minPriorityBackgroundJobPerformer = mock(BackgroundJobPerformer.class);
-            BackgroundJobPerformerFactory minPriorityJobPerformerFactory = mock(BackgroundJobPerformerFactory.class);
-            when(minPriorityJobPerformerFactory.newBackgroundJobPerformer(any(), any()))
-                    .thenReturn(minPriorityBackgroundJobPerformer);
-            when(minPriorityJobPerformerFactory.getPriority())
-                    .thenReturn(5);
-
-            BackgroundJobPerformer maxPriorityBackgroundJobPerformer = mock(BackgroundJobPerformer.class);
-            BackgroundJobPerformerFactory maxPriorityJobPerformerFactory = mock(BackgroundJobPerformerFactory.class);
-            when(maxPriorityJobPerformerFactory.newBackgroundJobPerformer(any(), any()))
-                    .thenReturn(maxPriorityBackgroundJobPerformer);
-            when(maxPriorityJobPerformerFactory.getPriority())
-                    .thenReturn(15);
-
-            ServiceLoader<BackgroundJobPerformerFactory> backgroundJobPerformerFactoryServiceLoader = mock(ServiceLoader.class);
-            when(backgroundJobPerformerFactoryServiceLoader.iterator()).thenReturn(Stream.of(minPriorityJobPerformerFactory, maxPriorityJobPerformerFactory).iterator());
-
-
-            serviceLoaderMock.when(() -> ServiceLoader.load(JobRunrExecutor.class)).thenReturn(jobRunrExecutorServiceLoader);
-            serviceLoaderMock.when(() -> ServiceLoader.load(BackgroundJobPerformerFactory.class)).thenReturn(backgroundJobPerformerFactoryServiceLoader);
-
-            BackgroundJobServer jobServer = new BackgroundJobServer(storageProvider, mock(JsonMapper.class), jobActivator, usingStandardBackgroundJobServerConfiguration());
-            jobServer.start();
-
-            // act
-            jobServer.processJob(mock(Job.class));
-
-            // assert
-            verify(minPriorityJobPerformerFactory, never()).newBackgroundJobPerformer(any(), any());
-            verify(jobRunrExecutor, never()).execute(eq(minPriorityBackgroundJobPerformer));
-
-            verify(maxPriorityJobPerformerFactory).newBackgroundJobPerformer(any(), any());
-            verify(jobRunrExecutor).execute(eq(maxPriorityBackgroundJobPerformer));
-        }
-    }
-
-    @Test
-    void testProcessJobUsesDefaultBackgroundJobPerformerFactoryWhenNoneAvailable() {
-        try (MockedStatic<ServiceLoader> serviceLoaderMock = Mockito.mockStatic(ServiceLoader.class)) {
-
-            // arrange
-            JobRunrExecutor jobRunrExecutor = mock(JobRunrExecutor.class);
-            ServiceLoader<JobRunrExecutor> jobRunrExecutorServiceLoader = mock(ServiceLoader.class);
-            when(jobRunrExecutorServiceLoader.iterator())
-                    .thenReturn(Stream.of(jobRunrExecutor).iterator());
-
-            ServiceLoader<BackgroundJobPerformerFactory> backgroundJobPerformerFactoryServiceLoader = mock(ServiceLoader.class);
-            when(backgroundJobPerformerFactoryServiceLoader.iterator())
-                    .thenReturn(Stream.<BackgroundJobPerformerFactory>empty().iterator());
-
-
-            serviceLoaderMock.when(() -> ServiceLoader.load(JobRunrExecutor.class)).thenReturn(jobRunrExecutorServiceLoader);
-            serviceLoaderMock.when(() -> ServiceLoader.load(BackgroundJobPerformerFactory.class)).thenReturn(backgroundJobPerformerFactoryServiceLoader);
-
-            BackgroundJobServer jobServer = new BackgroundJobServer(storageProvider, mock(JsonMapper.class), jobActivator, usingStandardBackgroundJobServerConfiguration());
-            jobServer.start();
-
-            JobDetails jobDetails = mock(JobDetails.class);
-            when(jobDetails.getClassName()).thenReturn("java");
-            Job job = mock(Job.class);
-            when(job.getJobDetails()).thenReturn(jobDetails);
-
-            // act
-            jobServer.processJob(job);
-
-            // assert
-            serviceLoaderMock.verify(() -> ServiceLoader.load(BackgroundJobPerformerFactory.class));
-            verify(jobRunrExecutor).execute(any(BackgroundJobPerformer.class));
-        }
     }
 
     private boolean containsNoBackgroundJobThreads(Map<Thread, StackTraceElement[]> threadMap) {

--- a/core/src/test/java/org/jobrunr/server/BackgroundJobServerUsesBackJobPerformerFactoryTest.java
+++ b/core/src/test/java/org/jobrunr/server/BackgroundJobServerUsesBackJobPerformerFactoryTest.java
@@ -1,0 +1,115 @@
+package org.jobrunr.server;
+
+import org.jobrunr.jobs.Job;
+import org.jobrunr.jobs.stubs.SimpleJobActivator;
+import org.jobrunr.server.threadpool.JobRunrExecutor;
+import org.jobrunr.storage.InMemoryStorageProvider;
+import org.jobrunr.storage.StorageProvider;
+import org.jobrunr.stubs.TestServiceForIoC;
+import org.jobrunr.utils.mapper.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ServiceLoader;
+import java.util.stream.Stream;
+
+import static org.jobrunr.jobs.JobTestBuilder.aJobInProgress;
+import static org.jobrunr.server.BackgroundJobServerConfiguration.usingStandardBackgroundJobServerConfiguration;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BackgroundJobServerUsesBackJobPerformerFactoryTest {
+
+    private StorageProvider storageProvider;
+
+    private SimpleJobActivator jobActivator;
+
+    @Mock
+    private JobRunrExecutor jobRunrExecutor;
+    @Mock
+    private ServiceLoader<JobRunrExecutor> jobRunrExecutorServiceLoader;
+
+    @BeforeEach
+    void setUp() {
+        storageProvider = Mockito.spy(new InMemoryStorageProvider());
+        jobActivator = new SimpleJobActivator(new TestServiceForIoC("an argument"));
+
+        when(jobRunrExecutorServiceLoader.iterator()).thenReturn(Stream.of(jobRunrExecutor).iterator());
+    }
+
+    @Test
+    void testProcessJobUsesBackgroundJobPerformerFactoryWithMaximumPriorityWhenAvailable() {
+        try (MockedStatic<ServiceLoader> serviceLoaderMock = Mockito.mockStatic(ServiceLoader.class)) {
+            // GIVEN
+            BackgroundJobPerformer minPriorityBackgroundJobPerformer = mock(BackgroundJobPerformer.class);
+            BackgroundJobPerformerFactory minPriorityJobPerformerFactory = mockBackgroundJobPerformerFactory(minPriorityBackgroundJobPerformer, 5);
+
+            BackgroundJobPerformer maxPriorityBackgroundJobPerformer = mock(BackgroundJobPerformer.class);
+            BackgroundJobPerformerFactory maxPriorityJobPerformerFactory = mockBackgroundJobPerformerFactory(maxPriorityBackgroundJobPerformer, 15);
+
+            ServiceLoader<BackgroundJobPerformerFactory> backgroundJobPerformerFactoryServiceLoader = mock(ServiceLoader.class);
+            when(backgroundJobPerformerFactoryServiceLoader.iterator()).thenReturn(Stream.of(minPriorityJobPerformerFactory, maxPriorityJobPerformerFactory).iterator());
+
+            serviceLoaderMock.when(() -> ServiceLoader.load(JobRunrExecutor.class)).thenReturn(jobRunrExecutorServiceLoader);
+            serviceLoaderMock.when(() -> ServiceLoader.load(BackgroundJobPerformerFactory.class)).thenReturn(backgroundJobPerformerFactoryServiceLoader);
+
+            BackgroundJobServer backgroundJobServer = new BackgroundJobServer(storageProvider, mock(JsonMapper.class), jobActivator, usingStandardBackgroundJobServerConfiguration());
+            backgroundJobServer.start();
+
+            // WHEN
+            backgroundJobServer.processJob(mock(Job.class));
+
+            // THEN
+            verify(minPriorityJobPerformerFactory, never()).newBackgroundJobPerformer(any(), any());
+            verify(jobRunrExecutor, never()).execute(eq(minPriorityBackgroundJobPerformer));
+
+            verify(maxPriorityJobPerformerFactory).newBackgroundJobPerformer(any(), any());
+            verify(jobRunrExecutor).execute(eq(maxPriorityBackgroundJobPerformer));
+
+            // CLEANUP
+            backgroundJobServer.stop();
+        }
+    }
+
+    @Test
+    void testProcessJobUsesDefaultBackgroundJobPerformerFactoryWhenNoneAvailable() {
+        try (MockedStatic<ServiceLoader> serviceLoaderMock = Mockito.mockStatic(ServiceLoader.class)) {
+
+            // GIVEN
+            ServiceLoader<BackgroundJobPerformerFactory> backgroundJobPerformerFactoryServiceLoader = mock(ServiceLoader.class);
+            when(backgroundJobPerformerFactoryServiceLoader.iterator())
+                    .thenReturn(Stream.<BackgroundJobPerformerFactory>empty().iterator());
+
+            serviceLoaderMock.when(() -> ServiceLoader.load(JobRunrExecutor.class)).thenReturn(jobRunrExecutorServiceLoader);
+            serviceLoaderMock.when(() -> ServiceLoader.load(BackgroundJobPerformerFactory.class)).thenReturn(backgroundJobPerformerFactoryServiceLoader);
+
+            BackgroundJobServer backgroundJobServer = new BackgroundJobServer(storageProvider, mock(JsonMapper.class), jobActivator, usingStandardBackgroundJobServerConfiguration());
+            backgroundJobServer.start();
+
+            // WHEN
+            backgroundJobServer.processJob(aJobInProgress().build());
+
+            // THEN
+            serviceLoaderMock.verify(() -> ServiceLoader.load(BackgroundJobPerformerFactory.class));
+            verify(jobRunrExecutor).execute(any(BackgroundJobPerformer.class));
+
+            // CLEANUP
+            backgroundJobServer.stop();
+        }
+    }
+
+    private BackgroundJobPerformerFactory mockBackgroundJobPerformerFactory(BackgroundJobPerformer backgroundJobPerformer, int priority) {
+        BackgroundJobPerformerFactory backgroundJobPerformerFactory = mock(BackgroundJobPerformerFactory.class);
+        lenient().when(backgroundJobPerformerFactory.newBackgroundJobPerformer(any(), any())).thenReturn(backgroundJobPerformer);
+        when(backgroundJobPerformerFactory.getPriority()).thenReturn(priority);
+        return backgroundJobPerformerFactory;
+    }
+
+}


### PR DESCRIPTION
- BackgroundJobPerformerFactory implementation
  - Factory with maximum priority is loaded and, if none exists, the default implementation is used
- BackgroundJobPerformer job processing is now overridable
