### PR TITLE
Add max back-off interval to RetryFilter

### DIFF
--- a/core/src/main/java/org/jobrunr/jobs/filters/RetryFilter.java
+++ b/core/src/main/java/org/jobrunr/jobs/filters/RetryFilter.java
@@ -26,21 +26,28 @@ public class RetryFilter implements ElectStateFilter {
 
     public static final int DEFAULT_BACKOFF_POLICY_TIME_SEED = 3;
     public static final int DEFAULT_NBR_OF_RETRIES = 10;
+    public static final long DEFAULT_MAX_BACKOFF_SECONDS = 0;
 
     private final int numberOfRetries;
     private final int backOffPolicyTimeSeed;
+    private final long maxBackoffSeconds;
 
     public RetryFilter() {
         this(DEFAULT_NBR_OF_RETRIES);
     }
 
     public RetryFilter(int numberOfRetries) {
-        this(numberOfRetries, DEFAULT_BACKOFF_POLICY_TIME_SEED);
+        this(numberOfRetries, DEFAULT_BACKOFF_POLICY_TIME_SEED, DEFAULT_MAX_BACKOFF_SECONDS);
     }
 
     public RetryFilter(int numberOfRetries, int backOffPolicyTimeSeed) {
+        this(numberOfRetries, backOffPolicyTimeSeed, DEFAULT_MAX_BACKOFF_SECONDS);
+    }
+
+    public RetryFilter(int numberOfRetries, int backOffPolicyTimeSeed, long maxBackoffSeconds) {
         this.numberOfRetries = numberOfRetries;
         this.backOffPolicyTimeSeed = backOffPolicyTimeSeed;
+        this.maxBackoffSeconds = maxBackoffSeconds;
     }
 
     @Override
@@ -52,7 +59,11 @@ public class RetryFilter implements ElectStateFilter {
     }
 
     protected long getSecondsToAdd(Job job) {
-        return getExponentialBackoffPolicy(job, backOffPolicyTimeSeed);
+        final long secondsToAdd = getExponentialBackoffPolicy(job, backOffPolicyTimeSeed);
+        if (maxBackoffSeconds > 0) {
+            return Math.min(secondsToAdd, maxBackoffSeconds);
+        }
+        return secondsToAdd;
     }
 
     protected long getExponentialBackoffPolicy(Job job, int seed) {

--- a/framework-support/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
@@ -71,7 +71,7 @@ public class JobRunrAutoConfiguration {
     @ConditionalOnProperty(prefix = "org.jobrunr.background-job-server", name = "enabled", havingValue = "true")
     public BackgroundJobServer backgroundJobServer(StorageProvider storageProvider, JsonMapper jobRunrJsonMapper, JobActivator jobActivator, BackgroundJobServerConfiguration backgroundJobServerConfiguration, JobRunrProperties properties) {
         final BackgroundJobServer backgroundJobServer = new BackgroundJobServer(storageProvider, jobRunrJsonMapper, jobActivator, backgroundJobServerConfiguration);
-        backgroundJobServer.setJobFilters(singletonList(new RetryFilter(properties.getJobs().getDefaultNumberOfRetries(), properties.getJobs().getRetryBackOffTimeSeed())));
+        backgroundJobServer.setJobFilters(singletonList(new RetryFilter(properties.getJobs().getDefaultNumberOfRetries(), properties.getJobs().getRetryBackOffTimeSeed(), properties.getJobs().getMaxBackoffSeconds())));
         backgroundJobServer.start();
         return backgroundJobServer;
     }

--- a/framework-support/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrProperties.java
+++ b/framework-support/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrProperties.java
@@ -157,6 +157,11 @@ public class JobRunrProperties {
          */
         private int backOffTimeSeed = RetryFilter.DEFAULT_BACKOFF_POLICY_TIME_SEED;
 
+        /**
+         * Configures a max interval for the exponential back-off. Default value '0' will disable.
+         */
+        private long maxBackoffSeconds = RetryFilter.DEFAULT_MAX_BACKOFF_SECONDS;
+
         public int getDefaultNumberOfRetries() {
             return defaultNumberOfRetries;
         }
@@ -171,6 +176,14 @@ public class JobRunrProperties {
 
         public void setRetryBackOffTimeSeed(int backOffTimeSeed) {
             this.backOffTimeSeed = backOffTimeSeed;
+        }
+
+        public long getMaxBackoffSeconds() {
+            return maxBackoffSeconds;
+        }
+
+        public void setMaxBackoffSeconds(long maxBackoffSeconds) {
+            this.maxBackoffSeconds = maxBackoffSeconds;
         }
     }
 


### PR DESCRIPTION
Hi!
I have a draft of a maximum backoff to the RetryFilter. It sets a roof of the exponential backoff when jobs are scheduled for retries.

Before I continue to add properties to all frameworks, I want to ask. Is this something that you'd consider merging?
