### PR TITLE
Added 'Automatic-Module-Name' entries to the generated MANIFEST.MF files

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -98,6 +98,7 @@ compileTestFixturesJava {
 jar {
     exclude('**/dependency-check-bin/', '**/dependency-check-reports/')
     manifest {
+        attributes 'Automatic-Module-Name' : 'org.jobrunr.core'
         attributes 'Built-By': 'build.jobrunr.io'
         attributes 'Build-Timestamp': new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date())
         attributes 'Build-Version': project.version

--- a/framework-support/jobrunr-micronaut-feature/build.gradle
+++ b/framework-support/jobrunr-micronaut-feature/build.gradle
@@ -1,3 +1,5 @@
+import java.text.SimpleDateFormat
+
 plugins {
     id 'java-library'
     id 'io.micronaut.library' version '3.3.2'
@@ -37,6 +39,20 @@ dependencies {
     testImplementation 'org.mongodb:mongodb-driver-sync'
     testImplementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
     testImplementation 'io.micrometer:micrometer-core'
+}
+
+jar {
+    manifest {
+        attributes 'Automatic-Module-Name' : 'org.jobrunr.micronaut'
+        attributes 'Built-By': 'build.jobrunr.io'
+        attributes 'Build-Timestamp': new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date())
+        attributes 'Build-Version': project.version
+        attributes 'Implementation-Version': project.version
+        attributes 'Bundle-Version': project.version
+        attributes 'Created-By': "Gradle ${gradle.gradleVersion}"
+        attributes 'Build-Jdk': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})"
+        attributes 'Build-OS': "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+    }
 }
 
 publishing {

--- a/framework-support/jobrunr-quarkus-extension/deployment/build.gradle
+++ b/framework-support/jobrunr-quarkus-extension/deployment/build.gradle
@@ -1,3 +1,5 @@
+import java.text.SimpleDateFormat
+
 plugins {
     id 'java-library'
     id 'maven-publish'
@@ -27,6 +29,20 @@ java {
 test {
     systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
     systemProperty "platform.quarkus.native.builder-image", false
+}
+
+jar {
+    manifest {
+        attributes 'Automatic-Module-Name' : 'org.jobrunr.quarkus.deployment'
+        attributes 'Built-By': 'build.jobrunr.io'
+        attributes 'Build-Timestamp': new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date())
+        attributes 'Build-Version': project.version
+        attributes 'Implementation-Version': project.version
+        attributes 'Bundle-Version': project.version
+        attributes 'Created-By': "Gradle ${gradle.gradleVersion}"
+        attributes 'Build-Jdk': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})"
+        attributes 'Build-OS': "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+    }
 }
 
 publishing {

--- a/framework-support/jobrunr-quarkus-extension/runtime/build.gradle
+++ b/framework-support/jobrunr-quarkus-extension/runtime/build.gradle
@@ -1,5 +1,7 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
+import java.text.SimpleDateFormat
+
 plugins {
     id 'java-library'
     id 'maven-publish'
@@ -46,6 +48,20 @@ dependencies {
 java {
     withJavadocJar()
     withSourcesJar()
+}
+
+jar {
+    manifest {
+        attributes 'Automatic-Module-Name' : 'org.jobrunr.quarkus'
+        attributes 'Built-By': 'build.jobrunr.io'
+        attributes 'Build-Timestamp': new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date())
+        attributes 'Build-Version': project.version
+        attributes 'Implementation-Version': project.version
+        attributes 'Bundle-Version': project.version
+        attributes 'Created-By': "Gradle ${gradle.gradleVersion}"
+        attributes 'Build-Jdk': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})"
+        attributes 'Build-OS': "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+    }
 }
 
 publishing {

--- a/framework-support/jobrunr-spring-boot-native/build.gradle
+++ b/framework-support/jobrunr-spring-boot-native/build.gradle
@@ -1,3 +1,5 @@
+import java.text.SimpleDateFormat
+
 plugins {
     id 'java-library'
     id 'maven-publish'
@@ -33,6 +35,17 @@ bootJar {
 
 jar {
     archiveClassifier = ''
+    manifest {
+        attributes 'Automatic-Module-Name' : 'org.jobrunr.spring.boot.native'
+        attributes 'Built-By': 'build.jobrunr.io'
+        attributes 'Build-Timestamp': new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date())
+        attributes 'Build-Version': project.version
+        attributes 'Implementation-Version': project.version
+        attributes 'Bundle-Version': project.version
+        attributes 'Created-By': "Gradle ${gradle.gradleVersion}"
+        attributes 'Build-Jdk': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})"
+        attributes 'Build-OS': "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+    }
 }
 
 publishing {

--- a/framework-support/jobrunr-spring-boot-starter/build.gradle
+++ b/framework-support/jobrunr-spring-boot-starter/build.gradle
@@ -1,3 +1,5 @@
+import java.text.SimpleDateFormat
+
 plugins {
     id 'java-library'
     id 'maven-publish'
@@ -40,6 +42,20 @@ dependencies {
 java {
     withJavadocJar()
     withSourcesJar()
+}
+
+jar {
+    manifest {
+        attributes 'Automatic-Module-Name' : 'org.jobrunr.spring.boot.starter'
+        attributes 'Built-By': 'build.jobrunr.io'
+        attributes 'Build-Timestamp': new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date())
+        attributes 'Build-Version': project.version
+        attributes 'Implementation-Version': project.version
+        attributes 'Bundle-Version': project.version
+        attributes 'Created-By': "Gradle ${gradle.gradleVersion}"
+        attributes 'Build-Jdk': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})"
+        attributes 'Build-OS': "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+    }
 }
 
 publishing {


### PR DESCRIPTION
Partially implements #525 

For the framework modules, I had to add a jar task to the Gradle build files as they didn't exist yet. As I am not that familiar with Gradle and the project, it might be good practice to check configuration I've added.

Also, I did not add that manifest.mf modifications to the kotlin-1x-support modules. Please let me know if it has to be added as well to those modules.

Finally, check whether the proposed module names are chosen correctly.

Replaces PR #527 