### PR TITLE
fix : Spring AutoConfiguration > jobRunR try to declare metrics even …

### DIFF
--- a/framework-support/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/spring/autoconfigure/metrics/JobRunrMetricsAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-starter/src/main/java/org/jobrunr/spring/autoconfigure/metrics/JobRunrMetricsAutoConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.Configuration;
 public class JobRunrMetricsAutoConfiguration {
 
     @Bean
+    @ConditionalOnBean({BackgroundJobServer.class})
     public StorageProviderMetricsBinder storageProviderMetricsBinder(StorageProvider storageProvider, MeterRegistry meterRegistry) {
         return new StorageProviderMetricsBinder(storageProvider, meterRegistry);
     }


### PR DESCRIPTION
During unit test, I want to disable jobRunR,

```
org.jobrunr:
 job-scheduler:
  enabled: false
 background-job-server:
  enabled: false
 dashboard:
  enabled: false
```

The problem is JobRunrMetricsAutoConfiguration still try to create StorageProviderMetricsBinder even if there is no StorageProvider and no BackgroundJobServer.

I add a @ConditionalOnBean to avoid that issue.