### PR TITLE
Fix jobrunr#643

### DIFF
--- a/core/src/main/java/org/jobrunr/jobs/Job.java
+++ b/core/src/main/java/org/jobrunr/jobs/Job.java
@@ -182,6 +182,6 @@ public class Job extends AbstractJob {
     }
 
     private void clearMetadata() {
-        metadata.entrySet().removeIf(entry -> !(entry.getKey().matches("(\\b" + JobDashboardLogger.JOBRUNR_LOG_KEY + "\\b|\\b" + JobDashboardProgressBar.JOBRUNR_PROGRESSBAR_KEY + "\\b)-(\\d)")));
+        metadata.entrySet().removeIf(entry -> !(entry.getKey().matches("(\\b" + JobDashboardLogger.JOBRUNR_LOG_KEY + "\\b|\\b" + JobDashboardProgressBar.JOBRUNR_PROGRESSBAR_KEY + "\\b)-(\\d+)")));
     }
 }


### PR DESCRIPTION
Metadata logs keys can have more than one digit if the job has more than nine history slots.