### PR TITLE
Bug #499: migrate to Elasticsearch new Java API

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,24 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JetCodeStyleSettings>
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
+    <codeStyleSettings language="JAVA">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="XML">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
     <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -51,14 +51,6 @@
       <profile name="Gradle Imported" enabled="true">
         <outputRelativeToContentRoot value="true" />
         <processorPath useClasspath="false">
-          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework.boot/spring-boot-autoconfigure-processor/2.7.4/3cc2ed4a41e9bc20618b499e2936aeb3579ce10c/spring-boot-autoconfigure-processor-2.7.4.jar" />
-          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework.boot/spring-boot-configuration-processor/2.7.4/444e3980bdda8429a5055c9d55881dd66a61c85e/spring-boot-configuration-processor-2.7.4.jar" />
-        </processorPath>
-        <module name="JobRunr.framework-support.jobrunr-spring-boot-starter.main" />
-      </profile>
-      <profile name="Gradle Imported" enabled="true">
-        <outputRelativeToContentRoot value="true" />
-        <processorPath useClasspath="false">
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/io.quarkus/quarkus-extension-processor/2.13.0.Final/9ca9721c04e7c8ec223bdedbdf83736bf0274777/quarkus-extension-processor-2.13.0.Final.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jboss.jdeparser/jdeparser/2.0.3.Final/f1982f9caa0ed8a2663d4c648aaa9a82d14eb962/jdeparser-2.0.3.Final.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jsoup/jsoup/1.15.3/f6e1d8a8819f854b681c8eaa57fd59a42329e10c/jsoup-1.15.3.jar" />
@@ -69,6 +61,14 @@
         </processorPath>
         <module name="JobRunr.framework-support.jobrunr-quarkus-extension.deployment.main" />
         <module name="JobRunr.framework-support.jobrunr-quarkus-extension.runtime.main" />
+      </profile>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework.boot/spring-boot-autoconfigure-processor/2.7.7/5a83d3730dbfdeb58e8729cfed6976468849f7ae/spring-boot-autoconfigure-processor-2.7.7.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework.boot/spring-boot-configuration-processor/2.7.7/483f6acb3b0aff6c3d3dc99e8b8f390fa893d0a2/spring-boot-configuration-processor-2.7.7.jar" />
+        </processorPath>
+        <module name="JobRunr.framework-support.jobrunr-spring-boot-starter.main" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="11">

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -71,7 +71,11 @@
         <module name="JobRunr.framework-support.jobrunr-quarkus-extension.runtime.main" />
       </profile>
     </annotationProcessing>
-    <bytecodeTargetLevel target="1.8">
+    <bytecodeTargetLevel target="11">
+      <module name="JobRunr.framework-support.jobrunr-spring-boot-2-starter.test" target="11" />
+      <module name="JobRunr.framework-support.jobrunr-spring-boot-3-starter" target="17" />
+      <module name="JobRunr.framework-support.jobrunr-spring-boot-3-starter.main" target="17" />
+      <module name="JobRunr.framework-support.jobrunr-spring-boot-3-starter.test" target="17" />
       <module name="JobRunr.language-support.jobrunr-kotlin-14-support.test" target="11" />
     </bytecodeTargetLevel>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -14,7 +14,7 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/modules/framework-support/jobrunr-quarkus-extension/deployment/JobRunr.framework-support.jobrunr-quarkus-extension.deployment.main.iml
+++ b/.idea/modules/framework-support/jobrunr-quarkus-extension/deployment/JobRunr.framework-support.jobrunr-quarkus-extension.deployment.main.iml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="Quarkus Tools">
+    <option name="hash" value="-1338461454" />
+    <option name="version" value="1" />
+  </component>
+</module>

--- a/.idea/modules/framework-support/jobrunr-quarkus-extension/deployment/JobRunr.framework-support.jobrunr-quarkus-extension.deployment.test.iml
+++ b/.idea/modules/framework-support/jobrunr-quarkus-extension/deployment/JobRunr.framework-support.jobrunr-quarkus-extension.deployment.test.iml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="Quarkus Tools">
+    <option name="hash" value="-70706382" />
+    <option name="version" value="1" />
+  </component>
+</module>

--- a/.idea/modules/framework-support/jobrunr-quarkus-extension/runtime/JobRunr.framework-support.jobrunr-quarkus-extension.runtime.main.iml
+++ b/.idea/modules/framework-support/jobrunr-quarkus-extension/runtime/JobRunr.framework-support.jobrunr-quarkus-extension.runtime.main.iml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="Quarkus Tools">
+    <option name="hash" value="-1649950196" />
+    <option name="version" value="1" />
+  </component>
+</module>

--- a/.idea/modules/framework-support/jobrunr-quarkus-extension/runtime/JobRunr.framework-support.jobrunr-quarkus-extension.runtime.test.iml
+++ b/.idea/modules/framework-support/jobrunr-quarkus-extension/runtime/JobRunr.framework-support.jobrunr-quarkus-extension.runtime.test.iml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="Quarkus Tools">
+    <option name="hash" value="-70706382" />
+    <option name="version" value="1" />
+  </component>
+</module>

--- a/.idea/modules/framework-support/jobrunr-quarkus-extension/tests/JobRunr.framework-support.jobrunr-quarkus-extension.tests.integrationTest.iml
+++ b/.idea/modules/framework-support/jobrunr-quarkus-extension/tests/JobRunr.framework-support.jobrunr-quarkus-extension.tests.integrationTest.iml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="Quarkus Tools">
+    <option name="hash" value="1581131826" />
+    <option name="version" value="1" />
+  </component>
+</module>

--- a/.idea/modules/framework-support/jobrunr-quarkus-extension/tests/JobRunr.framework-support.jobrunr-quarkus-extension.tests.main.iml
+++ b/.idea/modules/framework-support/jobrunr-quarkus-extension/tests/JobRunr.framework-support.jobrunr-quarkus-extension.tests.main.iml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="Quarkus Tools">
+    <option name="hash" value="1581131826" />
+    <option name="version" value="1" />
+  </component>
+</module>

--- a/.idea/modules/framework-support/jobrunr-quarkus-extension/tests/JobRunr.framework-support.jobrunr-quarkus-extension.tests.native-test.iml
+++ b/.idea/modules/framework-support/jobrunr-quarkus-extension/tests/JobRunr.framework-support.jobrunr-quarkus-extension.tests.native-test.iml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="Quarkus Tools">
+    <option name="hash" value="1581131826" />
+    <option name="version" value="1" />
+  </component>
+</module>

--- a/.idea/modules/framework-support/jobrunr-quarkus-extension/tests/JobRunr.framework-support.jobrunr-quarkus-extension.tests.test.iml
+++ b/.idea/modules/framework-support/jobrunr-quarkus-extension/tests/JobRunr.framework-support.jobrunr-quarkus-extension.tests.test.iml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="Quarkus Tools">
+    <option name="hash" value="1581131826" />
+    <option name="version" value="1" />
+  </component>
+</module>

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ configure(subprojects.findAll {it.name != 'platform'}) {
     compileTestJava.options.encoding = 'UTF-8'
     javadoc.options.encoding = 'UTF-8'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 
     compileTestJava {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compileOnly 'redis.clients:jedis'
     compileOnly 'io.lettuce:lettuce-core'
     compileOnly 'org.mongodb:mongodb-driver-sync'
-    compileOnly 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
+    compileOnly 'co.elastic.clients:elasticsearch-java'
 
     testImplementation 'org.ow2.asm:asm-util'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'
@@ -76,7 +76,7 @@ dependencies {
     testImplementation 'redis.clients:jedis'
     testImplementation 'io.lettuce:lettuce-core'
     testImplementation 'org.mongodb:mongodb-driver-sync'
-    testImplementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
+    testImplementation 'co.elastic.clients:elasticsearch-java'
 
     testFixturesApi 'org.assertj:assertj-core'
     testFixturesApi 'org.junit.jupiter:junit-jupiter'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 
     api 'org.slf4j:slf4j-api'
     api 'org.ow2.asm:asm'
+    api 'org.glassfish:jakarta.json:1.1.6'
 
     compileOnly 'com.fasterxml.jackson.core:jackson-databind'
     compileOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDBCreator.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDBCreator.java
@@ -1,5 +1,6 @@
 package org.jobrunr.storage.nosql.elasticsearch;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
@@ -39,7 +40,7 @@ import static org.jobrunr.utils.StringUtils.substringBefore;
 public class ElasticSearchDBCreator extends NoSqlDatabaseCreator<ElasticSearchMigration> {
 
     public static final String JOBRUNR_MIGRATIONS_INDEX_NAME = JOBRUNR_PREFIX + Migrations.NAME;
-    private final RestHighLevelClient client;
+    private final ElasticsearchClient client;
     private final String indexPrefix;
     private final String migrationIndexName;
 

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDBCreator.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDBCreator.java
@@ -91,7 +91,7 @@ public class ElasticSearchDBCreator extends NoSqlDatabaseCreator<ElasticSearchMi
     }
 
     @Override
-    protected boolean markMigrationAsDone(NoSqlMigration noSqlMigration) {
+    protected boolean markMigrationAsDone(final NoSqlMigration noSqlMigration) {
         try {
             final Map<String, Object> map = new LinkedHashMap<>();
             map.put(Migrations.FIELD_NAME, noSqlMigration.getClassName());
@@ -107,11 +107,11 @@ public class ElasticSearchDBCreator extends NoSqlDatabaseCreator<ElasticSearchMi
         }
     }
 
-    private boolean isNewMigration(NoSqlMigration noSqlMigration, int retry) {
+    private boolean isNewMigration(final NoSqlMigration noSqlMigration, final int retry) {
         sleep(retry * 500L);
         try {
             waitForHealthyCluster(client);
-            BooleanResponse migration = client.exists(
+            final BooleanResponse migration = client.exists(
               r -> r.index(migrationIndexName).id(substringBefore(noSqlMigration.getClassName(), "_"))
             );
             return !migration.value();

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDBCreator.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDBCreator.java
@@ -95,7 +95,7 @@ public class ElasticSearchDBCreator extends NoSqlDatabaseCreator<ElasticSearchMi
         try {
             final Map<String, Object> map = new LinkedHashMap<>();
             map.put(Migrations.FIELD_NAME, noSqlMigration.getClassName());
-            map.put(Migrations.FIELD_DATE, Instant.now());
+            map.put(Migrations.FIELD_DATE, Instant.now().toEpochMilli());
             return client.index(r ->
               r.index(migrationIndexName)
                 .id(substringBefore(noSqlMigration.getClassName(), "_"))

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDocumentMapper.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDocumentMapper.java
@@ -128,19 +128,19 @@ public class ElasticSearchDocumentMapper {
 
     public Job toJob(final GetResponse<Map<Object, Object>> response) {
         final JsonData jsonData = response.fields().get(Jobs.FIELD_JOB_AS_JSON);
-        final String jobAsJson = jsonData.toString();
+        final String jobAsJson = jsonData.toJson().asJsonArray().get(0).toString();
         return jobMapper.deserializeJob(jobAsJson);
     }
 
     public Job toJob(final Hit<Map<Object, Object>> hit) {
         final JsonData jsonData = hit.fields().get(Jobs.FIELD_JOB_AS_JSON);
-        final String jobAsJson = jsonData.toString();
+        final String jobAsJson = jsonData.toJson().asJsonArray().get(0).toString();
         return jobMapper.deserializeJob(jobAsJson);
     }
 
     public RecurringJob toRecurringJob(final Hit<?> hit) {
         final JsonData jsonData = hit.fields().get(Jobs.FIELD_JOB_AS_JSON);
-        final String jobAsJson = jsonData.toString();
+        final String jobAsJson = jsonData.toJson().asJsonArray().get(0).toString();
         return jobMapper.deserializeRecurringJob(jobAsJson);
     }
 }

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDocumentMapper.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDocumentMapper.java
@@ -1,9 +1,7 @@
 package org.jobrunr.storage.nosql.elasticsearch;
 
-import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.json.JsonXContent;
+import co.elastic.clients.elasticsearch.core.GetResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
 import org.jobrunr.jobs.Job;
 import org.jobrunr.jobs.RecurringJob;
 import org.jobrunr.jobs.mappers.JobMapper;
@@ -11,16 +9,16 @@ import org.jobrunr.jobs.states.ScheduledState;
 import org.jobrunr.jobs.states.StateName;
 import org.jobrunr.storage.BackgroundJobServerStatus;
 import org.jobrunr.storage.JobRunrMetadata;
-import org.jobrunr.storage.StorageProviderUtils.BackgroundJobServers;
 import org.jobrunr.storage.StorageProviderUtils.Jobs;
 import org.jobrunr.storage.StorageProviderUtils.RecurringJobs;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.jobrunr.storage.StorageProviderUtils.BackgroundJobServers.*;
 import static org.jobrunr.storage.StorageProviderUtils.Metadata;
 import static org.jobrunr.utils.reflection.ReflectionUtils.autobox;
 
@@ -32,157 +30,121 @@ public class ElasticSearchDocumentMapper {
         this.jobMapper = jobMapper;
     }
 
-    public XContentBuilder toXContentBuilderForInsert(BackgroundJobServerStatus serverStatus) {
-        try {
-            XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
-            builder.startObject();
-            builder.field(BackgroundJobServers.FIELD_ID, serverStatus.getId().toString());
-            builder.field(BackgroundJobServers.FIELD_WORKER_POOL_SIZE, serverStatus.getWorkerPoolSize());
-            builder.field(BackgroundJobServers.FIELD_POLL_INTERVAL_IN_SECONDS, serverStatus.getPollIntervalInSeconds());
-            builder.field(BackgroundJobServers.FIELD_DELETE_SUCCEEDED_JOBS_AFTER, serverStatus.getDeleteSucceededJobsAfter());
-            builder.field(BackgroundJobServers.FIELD_DELETE_DELETED_JOBS_AFTER, serverStatus.getPermanentlyDeleteDeletedJobsAfter());
-            builder.field(BackgroundJobServers.FIELD_FIRST_HEARTBEAT, serverStatus.getFirstHeartbeat());
-            builder.field(BackgroundJobServers.FIELD_LAST_HEARTBEAT, serverStatus.getLastHeartbeat());
-            builder.field(BackgroundJobServers.FIELD_IS_RUNNING, serverStatus.isRunning());
-            builder.field(BackgroundJobServers.FIELD_SYSTEM_TOTAL_MEMORY, serverStatus.getSystemTotalMemory());
-            builder.field(BackgroundJobServers.FIELD_SYSTEM_FREE_MEMORY, serverStatus.getSystemFreeMemory());
-            builder.field(BackgroundJobServers.FIELD_SYSTEM_CPU_LOAD, serverStatus.getSystemCpuLoad());
-            builder.field(BackgroundJobServers.FIELD_PROCESS_MAX_MEMORY, serverStatus.getProcessMaxMemory());
-            builder.field(BackgroundJobServers.FIELD_PROCESS_FREE_MEMORY, serverStatus.getProcessFreeMemory());
-            builder.field(BackgroundJobServers.FIELD_PROCESS_ALLOCATED_MEMORY, serverStatus.getProcessAllocatedMemory());
-            builder.field(BackgroundJobServers.FIELD_PROCESS_CPU_LOAD, serverStatus.getProcessCpuLoad());
-            builder.endObject();
-            return builder;
-        } catch (IOException e) {
-            throw new ShouldNotHappenException(e);
-        }
+    public Map<String, Object> toXContentBuilderForInsert(BackgroundJobServerStatus serverStatus) {
+        final Map<String, Object> map = new LinkedHashMap<>();
+        map.put(FIELD_ID, serverStatus.getId().toString());
+        map.put(FIELD_WORKER_POOL_SIZE, serverStatus.getWorkerPoolSize());
+        map.put(FIELD_POLL_INTERVAL_IN_SECONDS, serverStatus.getPollIntervalInSeconds());
+        map.put(FIELD_DELETE_SUCCEEDED_JOBS_AFTER, serverStatus.getDeleteSucceededJobsAfter());
+        map.put(FIELD_DELETE_DELETED_JOBS_AFTER, serverStatus.getPermanentlyDeleteDeletedJobsAfter());
+        map.put(FIELD_FIRST_HEARTBEAT, serverStatus.getFirstHeartbeat());
+        map.put(FIELD_LAST_HEARTBEAT, serverStatus.getLastHeartbeat());
+        map.put(FIELD_IS_RUNNING, serverStatus.isRunning());
+        map.put(FIELD_SYSTEM_TOTAL_MEMORY, serverStatus.getSystemTotalMemory());
+        map.put(FIELD_SYSTEM_FREE_MEMORY, serverStatus.getSystemFreeMemory());
+        map.put(FIELD_SYSTEM_CPU_LOAD, serverStatus.getSystemCpuLoad());
+        map.put(FIELD_PROCESS_MAX_MEMORY, serverStatus.getProcessMaxMemory());
+        map.put(FIELD_PROCESS_FREE_MEMORY, serverStatus.getProcessFreeMemory());
+        map.put(FIELD_PROCESS_ALLOCATED_MEMORY, serverStatus.getProcessAllocatedMemory());
+        map.put(FIELD_PROCESS_CPU_LOAD, serverStatus.getProcessCpuLoad());
+        return map;
     }
 
-    public XContentBuilder toXContentBuilderForUpdate(BackgroundJobServerStatus serverStatus) {
-        try {
-            XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
-            builder.startObject();
-            builder.field(BackgroundJobServers.FIELD_LAST_HEARTBEAT, serverStatus.getLastHeartbeat());
-            builder.field(BackgroundJobServers.FIELD_SYSTEM_FREE_MEMORY, serverStatus.getSystemFreeMemory());
-            builder.field(BackgroundJobServers.FIELD_SYSTEM_CPU_LOAD, serverStatus.getSystemCpuLoad());
-            builder.field(BackgroundJobServers.FIELD_PROCESS_FREE_MEMORY, serverStatus.getProcessFreeMemory());
-            builder.field(BackgroundJobServers.FIELD_PROCESS_ALLOCATED_MEMORY, serverStatus.getProcessAllocatedMemory());
-            builder.field(BackgroundJobServers.FIELD_PROCESS_CPU_LOAD, serverStatus.getProcessCpuLoad());
-            builder.endObject();
-            return builder;
-        } catch (IOException e) {
-            throw new ShouldNotHappenException(e);
-        }
+    public Map<String, Object> toXContentBuilderForUpdate(BackgroundJobServerStatus serverStatus) {
+        final Map<String, Object> map = new LinkedHashMap<>();
+        map.put(FIELD_LAST_HEARTBEAT, serverStatus.getLastHeartbeat());
+        map.put(FIELD_SYSTEM_FREE_MEMORY, serverStatus.getSystemFreeMemory());
+        map.put(FIELD_SYSTEM_CPU_LOAD, serverStatus.getSystemCpuLoad());
+        map.put(FIELD_PROCESS_FREE_MEMORY, serverStatus.getProcessFreeMemory());
+        map.put(FIELD_PROCESS_ALLOCATED_MEMORY, serverStatus.getProcessAllocatedMemory());
+        map.put(FIELD_PROCESS_CPU_LOAD, serverStatus.getProcessCpuLoad());
+        return map;
     }
 
-    public XContentBuilder toXContentBuilder(Job job) {
-        try {
-            XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
-            builder.startObject();
-            builder.field(Jobs.FIELD_JOB_AS_JSON, jobMapper.serializeJob(job));
-            builder.field(Jobs.FIELD_STATE, job.getState());
-            builder.field(Jobs.FIELD_UPDATED_AT, job.getUpdatedAt());
-            builder.field(Jobs.FIELD_JOB_SIGNATURE, job.getJobSignature());
-            if (job.hasState(StateName.SCHEDULED)) {
-                builder.field(Jobs.FIELD_SCHEDULED_AT, job.getLastJobStateOfType(ScheduledState.class).map(ScheduledState::getScheduledAt).orElseThrow(IllegalStateException::new));
-            }
-            if(job.getRecurringJobId().isPresent()) {
-                builder.field(Jobs.FIELD_RECURRING_JOB_ID, job.getRecurringJobId().get());
-            }
-            builder.endObject();
-            return builder;
-        } catch (IOException e) {
-            throw new ShouldNotHappenException(e);
+    public Map<String, Object> toXContentBuilder(Job job) {
+        final Map<String, Object> map = new LinkedHashMap<>();
+        map.put(Jobs.FIELD_JOB_AS_JSON, jobMapper.serializeJob(job));
+        map.put(Jobs.FIELD_STATE, job.getState());
+        map.put(Jobs.FIELD_UPDATED_AT, job.getUpdatedAt());
+        map.put(Jobs.FIELD_JOB_SIGNATURE, job.getJobSignature());
+        if (job.hasState(StateName.SCHEDULED)) {
+            map.put(Jobs.FIELD_SCHEDULED_AT, job.getLastJobStateOfType(ScheduledState.class).map(ScheduledState::getScheduledAt).orElseThrow(IllegalStateException::new));
         }
+        if(job.getRecurringJobId().isPresent()) {
+            map.put(Jobs.FIELD_RECURRING_JOB_ID, job.getRecurringJobId().get());
+        }
+        return map;
     }
 
-    public XContentBuilder toXContentBuilder(JobRunrMetadata metadata) {
-        try {
-            XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
-            builder.startObject();
-            builder.field(Metadata.FIELD_NAME, metadata.getName());
-            builder.field(Metadata.FIELD_OWNER, metadata.getOwner());
-            builder.field(Metadata.FIELD_VALUE, metadata.getValue());
-            builder.field(Metadata.FIELD_CREATED_AT, metadata.getCreatedAt());
-            builder.field(Metadata.FIELD_UPDATED_AT, metadata.getUpdatedAt());
-            builder.endObject();
-            return builder;
-        } catch (IOException e) {
-            throw new ShouldNotHappenException(e);
-        }
+    public Map<String, Object> toXContentBuilder(JobRunrMetadata metadata) {
+        final Map<String, Object> map = new LinkedHashMap<>();
+        map.put(Metadata.FIELD_NAME, metadata.getName());
+        map.put(Metadata.FIELD_OWNER, metadata.getOwner());
+        map.put(Metadata.FIELD_VALUE, metadata.getValue());
+        map.put(Metadata.FIELD_CREATED_AT, metadata.getCreatedAt());
+        map.put(Metadata.FIELD_UPDATED_AT, metadata.getUpdatedAt());
+        return map;
     }
 
-    public XContentBuilder toXContentBuilder(RecurringJob job) {
-        try {
-            XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
-            builder.startObject();
-            builder.field(RecurringJobs.FIELD_JOB_AS_JSON, jobMapper.serializeRecurringJob(job));
-            builder.field(RecurringJobs.FIELD_CREATED_AT, job.getCreatedAt().toEpochMilli());
-            builder.endObject();
-            return builder;
-        } catch (IOException e) {
-            throw new ShouldNotHappenException(e);
-        }
+    public Map<String, Object> toXContentBuilder(RecurringJob job) {
+        final Map<String, Object> map = new LinkedHashMap<>();
+        map.put(RecurringJobs.FIELD_JOB_AS_JSON, jobMapper.serializeRecurringJob(job));
+        map.put(RecurringJobs.FIELD_CREATED_AT, job.getCreatedAt().toEpochMilli());
+        return map;
     }
 
-    public BackgroundJobServerStatus toBackgroundJobServerStatus(SearchHit searchHit) {
-        Map<String, Object> fieldMap = searchHit.getSourceAsMap();
+    public BackgroundJobServerStatus toBackgroundJobServerStatus(Hit<Map<String, Object>> searchHit) {
+        Map<String, Object> fieldMap = searchHit.source();
         return new BackgroundJobServerStatus(
-                autobox(fieldMap.get(BackgroundJobServers.FIELD_ID), UUID.class),
-                autobox(fieldMap.get(BackgroundJobServers.FIELD_WORKER_POOL_SIZE), int.class),
-                autobox(fieldMap.get(BackgroundJobServers.FIELD_POLL_INTERVAL_IN_SECONDS), int.class),
-                autobox(fieldMap.get(BackgroundJobServers.FIELD_DELETE_SUCCEEDED_JOBS_AFTER), Duration.class),
-                autobox(fieldMap.get(BackgroundJobServers.FIELD_DELETE_DELETED_JOBS_AFTER), Duration.class),
-                autobox(fieldMap.get(BackgroundJobServers.FIELD_FIRST_HEARTBEAT), Instant.class),
-                autobox(fieldMap.get(BackgroundJobServers.FIELD_LAST_HEARTBEAT), Instant.class),
-                autobox(fieldMap.get(BackgroundJobServers.FIELD_IS_RUNNING), boolean.class),
-                autobox(fieldMap.get(BackgroundJobServers.FIELD_SYSTEM_TOTAL_MEMORY), long.class),
-                autobox(fieldMap.get(BackgroundJobServers.FIELD_SYSTEM_FREE_MEMORY), long.class),
-                autobox(fieldMap.get(BackgroundJobServers.FIELD_SYSTEM_CPU_LOAD), double.class),
-                autobox(fieldMap.get(BackgroundJobServers.FIELD_PROCESS_MAX_MEMORY), long.class),
-                autobox(fieldMap.get(BackgroundJobServers.FIELD_PROCESS_FREE_MEMORY), long.class),
-                autobox(fieldMap.get(BackgroundJobServers.FIELD_PROCESS_ALLOCATED_MEMORY), long.class),
-                autobox(fieldMap.get(BackgroundJobServers.FIELD_PROCESS_CPU_LOAD), double.class)
+          autobox(fieldMap.get(FIELD_ID), UUID.class),
+          autobox(fieldMap.get(FIELD_WORKER_POOL_SIZE), int.class),
+          autobox(fieldMap.get(FIELD_POLL_INTERVAL_IN_SECONDS), int.class),
+          autobox(fieldMap.get(FIELD_DELETE_SUCCEEDED_JOBS_AFTER), Duration.class),
+          autobox(fieldMap.get(FIELD_DELETE_DELETED_JOBS_AFTER), Duration.class),
+          autobox(fieldMap.get(FIELD_FIRST_HEARTBEAT), Instant.class),
+          autobox(fieldMap.get(FIELD_LAST_HEARTBEAT), Instant.class),
+          autobox(fieldMap.get(FIELD_IS_RUNNING), boolean.class),
+          autobox(fieldMap.get(FIELD_SYSTEM_TOTAL_MEMORY), long.class),
+          autobox(fieldMap.get(FIELD_SYSTEM_FREE_MEMORY), long.class),
+          autobox(fieldMap.get(FIELD_SYSTEM_CPU_LOAD), double.class),
+          autobox(fieldMap.get(FIELD_PROCESS_MAX_MEMORY), long.class),
+          autobox(fieldMap.get(FIELD_PROCESS_FREE_MEMORY), long.class),
+          autobox(fieldMap.get(FIELD_PROCESS_ALLOCATED_MEMORY), long.class),
+          autobox(fieldMap.get(FIELD_PROCESS_CPU_LOAD), double.class)
         );
     }
 
-    public JobRunrMetadata toMetadata(SearchHit searchHit) {
-        return toMetadata(searchHit.getSourceAsMap());
+    public JobRunrMetadata toMetadata(Hit<Map<String, Object>> searchHit) {
+        return toMetadata(searchHit.source());
     }
 
-    public JobRunrMetadata toMetadata(GetResponse response) {
-        return toMetadata(response.getSourceAsMap());
+    public JobRunrMetadata toMetadata(GetResponse<Map<String, Object>> response) {
+        return toMetadata(response.source());
     }
 
     public JobRunrMetadata toMetadata(Map<String, Object> fieldMap) {
         if(fieldMap == null || fieldMap.isEmpty()) return null;
 
         return new JobRunrMetadata(
-                autobox(fieldMap.get(Metadata.FIELD_NAME), String.class),
-                autobox(fieldMap.get(Metadata.FIELD_OWNER), String.class),
-                autobox(fieldMap.get(Metadata.FIELD_VALUE), String.class),
-                autobox(fieldMap.get(Metadata.FIELD_CREATED_AT), Instant.class),
-                autobox(fieldMap.get(Metadata.FIELD_UPDATED_AT), Instant.class));
+          autobox(fieldMap.get(Metadata.FIELD_NAME), String.class),
+          autobox(fieldMap.get(Metadata.FIELD_OWNER), String.class),
+          autobox(fieldMap.get(Metadata.FIELD_VALUE), String.class),
+          autobox(fieldMap.get(Metadata.FIELD_CREATED_AT), Instant.class),
+          autobox(fieldMap.get(Metadata.FIELD_UPDATED_AT), Instant.class));
     }
 
 
     public Job toJob(GetResponse response) {
-        return jobMapper.deserializeJob(response.getField(Jobs.FIELD_JOB_AS_JSON).getValue());
+        return jobMapper.deserializeJob(response.fields().get(Jobs.FIELD_JOB_AS_JSON).toString());
     }
 
-    public Job toJob(SearchHit hit) {
-        String jobAsJson = hit.getFields().get(Jobs.FIELD_JOB_AS_JSON).getValue().toString();
+    public Job toJob(Hit<?> hit) {
+        String jobAsJson = hit.fields().get(Jobs.FIELD_JOB_AS_JSON).toString();
         return jobMapper.deserializeJob(jobAsJson);
     }
 
-    public RecurringJob toRecurringJob(SearchHit hit) {
-        String jobAsJson = hit.getFields().get(RecurringJobs.FIELD_JOB_AS_JSON).getValue().toString();
+    public RecurringJob toRecurringJob(Hit<?> hit) {
+        String jobAsJson = hit.fields().get(RecurringJobs.FIELD_JOB_AS_JSON).toString();
         return jobMapper.deserializeRecurringJob(jobAsJson);
-    }
-
-    static class ShouldNotHappenException extends RuntimeException {
-        public ShouldNotHappenException(Exception e) {
-            super("Should never happen", e);
-        }
     }
 }

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDocumentMapper.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDocumentMapper.java
@@ -129,7 +129,7 @@ public class ElasticSearchDocumentMapper {
         return jobMapper.deserializeJob(response.fields().get(Jobs.FIELD_JOB_AS_JSON).toString());
     }
 
-    public Job toJob(Hit<?> hit) {
+    public Job toJob(Hit<Map<Object, Object>> hit) {
         String jobAsJson = hit.fields().get(Jobs.FIELD_JOB_AS_JSON).toString();
         return jobMapper.deserializeJob(jobAsJson);
     }

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDocumentMapper.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDocumentMapper.java
@@ -30,7 +30,7 @@ public class ElasticSearchDocumentMapper {
         this.jobMapper = jobMapper;
     }
 
-    public Map<Object, Object> toXContentBuilderForInsert(BackgroundJobServerStatus serverStatus) {
+    public Map<Object, Object> toMap(BackgroundJobServerStatus serverStatus) {
         final Map<Object, Object> map = new LinkedHashMap<>();
         map.put(FIELD_ID, serverStatus.getId().toString());
         map.put(FIELD_WORKER_POOL_SIZE, serverStatus.getWorkerPoolSize());
@@ -50,7 +50,7 @@ public class ElasticSearchDocumentMapper {
         return map;
     }
 
-    public Map<Object, Object> toXContentBuilderForUpdate(BackgroundJobServerStatus serverStatus) {
+    public Map<Object, Object> toMapForUpdate(BackgroundJobServerStatus serverStatus) {
         final Map<Object, Object> map = new LinkedHashMap<>();
         map.put(FIELD_LAST_HEARTBEAT, serverStatus.getLastHeartbeat());
         map.put(FIELD_SYSTEM_FREE_MEMORY, serverStatus.getSystemFreeMemory());
@@ -61,7 +61,7 @@ public class ElasticSearchDocumentMapper {
         return map;
     }
 
-    public Map<Object, Object> toXContentBuilder(Job job) {
+    public Map<Object, Object> toMap(Job job) {
         final Map<Object, Object> map = new LinkedHashMap<>();
         map.put(Jobs.FIELD_JOB_AS_JSON, jobMapper.serializeJob(job));
         map.put(Jobs.FIELD_STATE, job.getState());
@@ -76,7 +76,7 @@ public class ElasticSearchDocumentMapper {
         return map;
     }
 
-    public Map<Object, Object> toXContentBuilder(JobRunrMetadata metadata) {
+    public Map<Object, Object> toMap(JobRunrMetadata metadata) {
         final Map<Object, Object> map = new LinkedHashMap<>();
         map.put(Metadata.FIELD_NAME, metadata.getName());
         map.put(Metadata.FIELD_OWNER, metadata.getOwner());
@@ -86,7 +86,7 @@ public class ElasticSearchDocumentMapper {
         return map;
     }
 
-    public Map<Object, Object> toXContentBuilder(RecurringJob job) {
+    public Map<Object, Object> toMap(RecurringJob job) {
         final Map<Object, Object> map = new LinkedHashMap<>();
         map.put(RecurringJobs.FIELD_JOB_AS_JSON, jobMapper.serializeRecurringJob(job));
         map.put(RecurringJobs.FIELD_CREATED_AT, job.getCreatedAt().toEpochMilli());

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDocumentMapper.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDocumentMapper.java
@@ -113,15 +113,7 @@ public class ElasticSearchDocumentMapper {
         );
     }
 
-    public JobRunrMetadata toMetadata(Hit<Map<String, Object>> searchHit) {
-        return toMetadata(searchHit.source());
-    }
-
-    public JobRunrMetadata toMetadata(GetResponse<Map<String, Object>> response) {
-        return toMetadata(response.source());
-    }
-
-    public JobRunrMetadata toMetadata(Map<String, Object> fieldMap) {
+    public JobRunrMetadata toMetadata(final Map<Object, Object> fieldMap) {
         if(fieldMap == null || fieldMap.isEmpty()) return null;
 
         return new JobRunrMetadata(

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDocumentMapper.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDocumentMapper.java
@@ -30,8 +30,8 @@ public class ElasticSearchDocumentMapper {
         this.jobMapper = jobMapper;
     }
 
-    public Map<String, Object> toXContentBuilderForInsert(BackgroundJobServerStatus serverStatus) {
-        final Map<String, Object> map = new LinkedHashMap<>();
+    public Map<Object, Object> toXContentBuilderForInsert(BackgroundJobServerStatus serverStatus) {
+        final Map<Object, Object> map = new LinkedHashMap<>();
         map.put(FIELD_ID, serverStatus.getId().toString());
         map.put(FIELD_WORKER_POOL_SIZE, serverStatus.getWorkerPoolSize());
         map.put(FIELD_POLL_INTERVAL_IN_SECONDS, serverStatus.getPollIntervalInSeconds());
@@ -50,8 +50,8 @@ public class ElasticSearchDocumentMapper {
         return map;
     }
 
-    public Map<String, Object> toXContentBuilderForUpdate(BackgroundJobServerStatus serverStatus) {
-        final Map<String, Object> map = new LinkedHashMap<>();
+    public Map<Object, Object> toXContentBuilderForUpdate(BackgroundJobServerStatus serverStatus) {
+        final Map<Object, Object> map = new LinkedHashMap<>();
         map.put(FIELD_LAST_HEARTBEAT, serverStatus.getLastHeartbeat());
         map.put(FIELD_SYSTEM_FREE_MEMORY, serverStatus.getSystemFreeMemory());
         map.put(FIELD_SYSTEM_CPU_LOAD, serverStatus.getSystemCpuLoad());
@@ -61,8 +61,8 @@ public class ElasticSearchDocumentMapper {
         return map;
     }
 
-    public Map<String, Object> toXContentBuilder(Job job) {
-        final Map<String, Object> map = new LinkedHashMap<>();
+    public Map<Object, Object> toXContentBuilder(Job job) {
+        final Map<Object, Object> map = new LinkedHashMap<>();
         map.put(Jobs.FIELD_JOB_AS_JSON, jobMapper.serializeJob(job));
         map.put(Jobs.FIELD_STATE, job.getState());
         map.put(Jobs.FIELD_UPDATED_AT, job.getUpdatedAt());
@@ -76,8 +76,8 @@ public class ElasticSearchDocumentMapper {
         return map;
     }
 
-    public Map<String, Object> toXContentBuilder(JobRunrMetadata metadata) {
-        final Map<String, Object> map = new LinkedHashMap<>();
+    public Map<Object, Object> toXContentBuilder(JobRunrMetadata metadata) {
+        final Map<Object, Object> map = new LinkedHashMap<>();
         map.put(Metadata.FIELD_NAME, metadata.getName());
         map.put(Metadata.FIELD_OWNER, metadata.getOwner());
         map.put(Metadata.FIELD_VALUE, metadata.getValue());
@@ -86,31 +86,30 @@ public class ElasticSearchDocumentMapper {
         return map;
     }
 
-    public Map<String, Object> toXContentBuilder(RecurringJob job) {
-        final Map<String, Object> map = new LinkedHashMap<>();
+    public Map<Object, Object> toXContentBuilder(RecurringJob job) {
+        final Map<Object, Object> map = new LinkedHashMap<>();
         map.put(RecurringJobs.FIELD_JOB_AS_JSON, jobMapper.serializeRecurringJob(job));
         map.put(RecurringJobs.FIELD_CREATED_AT, job.getCreatedAt().toEpochMilli());
         return map;
     }
 
-    public BackgroundJobServerStatus toBackgroundJobServerStatus(Hit<Map<String, Object>> searchHit) {
-        Map<String, Object> fieldMap = searchHit.source();
+    public BackgroundJobServerStatus toBackgroundJobServerStatus(Map<Object, Object> map) {
         return new BackgroundJobServerStatus(
-          autobox(fieldMap.get(FIELD_ID), UUID.class),
-          autobox(fieldMap.get(FIELD_WORKER_POOL_SIZE), int.class),
-          autobox(fieldMap.get(FIELD_POLL_INTERVAL_IN_SECONDS), int.class),
-          autobox(fieldMap.get(FIELD_DELETE_SUCCEEDED_JOBS_AFTER), Duration.class),
-          autobox(fieldMap.get(FIELD_DELETE_DELETED_JOBS_AFTER), Duration.class),
-          autobox(fieldMap.get(FIELD_FIRST_HEARTBEAT), Instant.class),
-          autobox(fieldMap.get(FIELD_LAST_HEARTBEAT), Instant.class),
-          autobox(fieldMap.get(FIELD_IS_RUNNING), boolean.class),
-          autobox(fieldMap.get(FIELD_SYSTEM_TOTAL_MEMORY), long.class),
-          autobox(fieldMap.get(FIELD_SYSTEM_FREE_MEMORY), long.class),
-          autobox(fieldMap.get(FIELD_SYSTEM_CPU_LOAD), double.class),
-          autobox(fieldMap.get(FIELD_PROCESS_MAX_MEMORY), long.class),
-          autobox(fieldMap.get(FIELD_PROCESS_FREE_MEMORY), long.class),
-          autobox(fieldMap.get(FIELD_PROCESS_ALLOCATED_MEMORY), long.class),
-          autobox(fieldMap.get(FIELD_PROCESS_CPU_LOAD), double.class)
+          autobox(map.get(FIELD_ID), UUID.class),
+          autobox(map.get(FIELD_WORKER_POOL_SIZE), int.class),
+          autobox(map.get(FIELD_POLL_INTERVAL_IN_SECONDS), int.class),
+          autobox(map.get(FIELD_DELETE_SUCCEEDED_JOBS_AFTER), Duration.class),
+          autobox(map.get(FIELD_DELETE_DELETED_JOBS_AFTER), Duration.class),
+          autobox(map.get(FIELD_FIRST_HEARTBEAT), Instant.class),
+          autobox(map.get(FIELD_LAST_HEARTBEAT), Instant.class),
+          autobox(map.get(FIELD_IS_RUNNING), boolean.class),
+          autobox(map.get(FIELD_SYSTEM_TOTAL_MEMORY), long.class),
+          autobox(map.get(FIELD_SYSTEM_FREE_MEMORY), long.class),
+          autobox(map.get(FIELD_SYSTEM_CPU_LOAD), double.class),
+          autobox(map.get(FIELD_PROCESS_MAX_MEMORY), long.class),
+          autobox(map.get(FIELD_PROCESS_FREE_MEMORY), long.class),
+          autobox(map.get(FIELD_PROCESS_ALLOCATED_MEMORY), long.class),
+          autobox(map.get(FIELD_PROCESS_CPU_LOAD), double.class)
         );
     }
 

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchStorageProvider.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchStorageProvider.java
@@ -159,7 +159,7 @@ public class ElasticSearchStorageProvider extends AbstractStorageProvider implem
               r.index(backgroundJobServerIndexName)
                 .id(status.getId().toString())
                 .refresh(True)
-                .document(mapper.toXContentBuilderForInsert(status))
+                .document(mapper.toMap(status))
             );
         } catch (final IOException e) {
             throw new StorageException(e);
@@ -169,7 +169,7 @@ public class ElasticSearchStorageProvider extends AbstractStorageProvider implem
     @Override
     public boolean signalBackgroundJobServerAlive(final BackgroundJobServerStatus status) {
         try {
-            final Map<Object, Object> value = mapper.toXContentBuilderForUpdate(status);
+            final Map<Object, Object> value = mapper.toMapForUpdate(status);
             final UpdateResponse<? extends Map> response = client.update(r ->
                 r
                   .index(backgroundJobServerIndexName)
@@ -274,7 +274,7 @@ public class ElasticSearchStorageProvider extends AbstractStorageProvider implem
                 .index(metadataIndexName)
                 .id(metadata.getId())
                 .refresh(True)
-                .document(mapper.toXContentBuilder(metadata))
+                .document(mapper.toMap(metadata))
             );
 
             notifyMetadataChangeListeners();
@@ -357,6 +357,7 @@ public class ElasticSearchStorageProvider extends AbstractStorageProvider implem
                 .id(job.getId().toString())
                 .versionType(VersionType.External)
                 .version((long) job.getVersion())
+                .document(mapper.toMap(job))
                 .refresh(True)
             );
 
@@ -433,7 +434,7 @@ public class ElasticSearchStorageProvider extends AbstractStorageProvider implem
                   .id(job.getId().toString())
                   .versionType(VersionType.External)
                   .version((long) job.getVersion())
-                  .document(mapper.toXContentBuilder(job));
+                  .document(mapper.toMap(job));
 
                 operations.add(builder.build()._toBulkOperation());
             }
@@ -636,7 +637,7 @@ public class ElasticSearchStorageProvider extends AbstractStorageProvider implem
             client.index(i -> i
               .index(recurringJobIndexName)
               .id(job.getId())
-              .document(mapper.toXContentBuilder(job))
+              .document(mapper.toMap(job))
               .refresh(True)
             );
 

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchStorageProvider.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchStorageProvider.java
@@ -166,12 +166,12 @@ public class ElasticSearchStorageProvider extends AbstractStorageProvider implem
     @Override
     public void announceBackgroundJobServer(final BackgroundJobServerStatus status) {
         try {
-            client.index(r -> {
-                r.index(backgroundJobServerIndexName)
-                  .id(status.getId().toString())
-                  .refresh(True)
-                  .document(documentMapper.toXContentBuilderForInsert(status))
-            });
+            client.index(r ->
+              r.index(backgroundJobServerIndexName)
+                .id(status.getId().toString())
+                .refresh(True)
+                .document(documentMapper.toXContentBuilderForInsert(status))
+            );
         } catch (final IOException e) {
             throw new StorageException(e);
         }

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchStorageProvider.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchStorageProvider.java
@@ -399,12 +399,12 @@ public class ElasticSearchStorageProvider extends AbstractStorageProvider implem
     @Override
     public Job getJobById(final UUID id) {
         try {
-            final GetResponse response = client.get(
+            final GetResponse<Map<Object, Object>> response = client.get(
               r -> r
                 .index(jobIndexName)
                 .id(id.toString())
                 .storedFields(Jobs.FIELD_JOB_AS_JSON),
-              Map.class
+              MAP_CLASS
             );
 
             if (response.found()) {

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchStorageProvider.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchStorageProvider.java
@@ -2,7 +2,9 @@ package org.jobrunr.storage.nosql.elasticsearch;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.VersionType;
 import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryVariant;
 import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
@@ -347,7 +349,14 @@ public class ElasticSearchStorageProvider extends AbstractStorageProvider implem
               .setRefreshPolicy(IMMEDIATE)
               .source(mapper.toXContentBuilder(job));
 
-            client.index(request, DEFAULT);
+            client.index(
+              i -> i
+                .index(jobIndexName)
+                .id(job.getId().toString())
+                .versionType(VersionType.External)
+                .version((long) job.getVersion())
+                .refresh(True)
+            );
             jobVersioner.commitVersion();
             notifyJobStatsOnChangeListeners();
             return job;

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/ElasticSearchMigration.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/ElasticSearchMigration.java
@@ -7,9 +7,6 @@ import co.elastic.clients.elasticsearch.indices.PutMappingRequest;
 import org.jobrunr.storage.StorageException;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.BiConsumer;
 
 import static co.elastic.clients.elasticsearch._types.HealthStatus.Yellow;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/M001_CreateJobsIndex.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/M001_CreateJobsIndex.java
@@ -1,18 +1,18 @@
 package org.jobrunr.storage.nosql.elasticsearch.migrations;
 
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.client.indices.CreateIndexRequest;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
 
 import java.io.IOException;
 
-import static org.jobrunr.storage.StorageProviderUtils.Jobs;
+import static org.jobrunr.storage.StorageProviderUtils.Jobs.*;
 import static org.jobrunr.storage.StorageProviderUtils.elementPrefixer;
 import static org.jobrunr.storage.nosql.elasticsearch.ElasticSearchStorageProvider.DEFAULT_JOB_INDEX_NAME;
 
 public class M001_CreateJobsIndex extends ElasticSearchMigration {
 
     @Override
-    public void runMigration(RestHighLevelClient client, String indexPrefix) throws IOException {
+    public void runMigration(ElasticsearchClient client, String indexPrefix) throws IOException {
         final String jobIndexName = elementPrefixer(indexPrefix, DEFAULT_JOB_INDEX_NAME);
         if (indexExists(client, jobIndexName))
             return; //why: to be compatible with existing installations not using Migrations yet
@@ -21,30 +21,15 @@ public class M001_CreateJobsIndex extends ElasticSearchMigration {
     }
 
     private static CreateIndexRequest jobIndex(String jobIndexName) {
-        return new CreateIndexRequest(jobIndexName)
-                .mapping(mapping(
-                        (sb, map) -> {
-                            sb.append(Jobs.FIELD_JOB_AS_JSON);
-                            map.put("type", "text");
-                            map.put("index", false);
-                            map.put("store", true);
-                        },
-                        (sb, map) -> {
-                            sb.append(Jobs.FIELD_STATE);
-                            map.put("type", "keyword");
-                        },
-                        (sb, map) -> {
-                            sb.append(Jobs.FIELD_JOB_SIGNATURE);
-                            map.put("type", "keyword");
-                        },
-                        (sb, map) -> {
-                            sb.append(Jobs.FIELD_SCHEDULED_AT);
-                            map.put("type", "date_nanos");
-                        },
-                        (sb, map) -> {
-                            sb.append(Jobs.FIELD_UPDATED_AT);
-                            map.put("type", "date_nanos");
-                        }
-                ));
+        return new CreateIndexRequest.Builder()
+          .index(jobIndexName)
+          .mappings(m -> m
+            .properties(FIELD_JOB_AS_JSON, p -> p.text(t -> t.index(false).store(true)))
+            .properties(FIELD_STATE, p -> p.keyword(k -> k))
+            .properties(FIELD_JOB_SIGNATURE, p -> p.keyword(k -> k))
+            .properties(FIELD_SCHEDULED_AT, p -> p.dateNanos(d -> d))
+            .properties(FIELD_UPDATED_AT, p -> p.dateNanos(d -> d))
+          )
+          .build();
     }
 }

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/M002_CreateRecurringJobsIndex.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/M002_CreateRecurringJobsIndex.java
@@ -1,18 +1,18 @@
 package org.jobrunr.storage.nosql.elasticsearch.migrations;
 
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.client.indices.CreateIndexRequest;
-import org.jobrunr.storage.StorageProviderUtils;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
 
 import java.io.IOException;
 
+import static org.jobrunr.storage.StorageProviderUtils.RecurringJobs.FIELD_JOB_AS_JSON;
 import static org.jobrunr.storage.StorageProviderUtils.elementPrefixer;
 import static org.jobrunr.storage.nosql.elasticsearch.ElasticSearchStorageProvider.DEFAULT_RECURRING_JOB_INDEX_NAME;
 
 public class M002_CreateRecurringJobsIndex extends ElasticSearchMigration {
 
     @Override
-    public void runMigration(RestHighLevelClient client, String indexPrefix) throws IOException {
+    public void runMigration(ElasticsearchClient client, String indexPrefix) throws IOException {
         final String recurringJobIndexName = elementPrefixer(indexPrefix, DEFAULT_RECURRING_JOB_INDEX_NAME);
         if (indexExists(client, recurringJobIndexName))
             return; //why: to be compatible with existing installations not using Migrations yet
@@ -20,15 +20,12 @@ public class M002_CreateRecurringJobsIndex extends ElasticSearchMigration {
         createIndex(client, recurringJobIndex(recurringJobIndexName));
     }
 
-    private static CreateIndexRequest recurringJobIndex(String recurringJobIndexName) {
-        return new CreateIndexRequest(recurringJobIndexName)
-                .mapping(mapping(
-                        (sb, map) -> {
-                            sb.append(StorageProviderUtils.RecurringJobs.FIELD_JOB_AS_JSON);
-                            map.put("type", "text");
-                            map.put("index", false);
-                            map.put("store", true);
-                        }
-                ));
-    }
+  private static CreateIndexRequest recurringJobIndex(String name) {
+    return new CreateIndexRequest.Builder()
+      .index(name)
+      .mappings(m -> m
+        .properties(FIELD_JOB_AS_JSON, p -> p.text(t -> t.index(false).store(true)))
+      )
+      .build();
+  }
 }

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/M003_CreateBackgroundJobServersIndex.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/M003_CreateBackgroundJobServersIndex.java
@@ -1,36 +1,33 @@
 package org.jobrunr.storage.nosql.elasticsearch.migrations;
 
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.client.indices.CreateIndexRequest;
-import org.jobrunr.storage.StorageProviderUtils;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
 
 import java.io.IOException;
 
+import static org.jobrunr.storage.StorageProviderUtils.BackgroundJobServers.FIELD_FIRST_HEARTBEAT;
+import static org.jobrunr.storage.StorageProviderUtils.BackgroundJobServers.FIELD_LAST_HEARTBEAT;
 import static org.jobrunr.storage.StorageProviderUtils.elementPrefixer;
 import static org.jobrunr.storage.nosql.elasticsearch.ElasticSearchStorageProvider.DEFAULT_BACKGROUND_JOB_SERVER_INDEX_NAME;
 
 public class M003_CreateBackgroundJobServersIndex extends ElasticSearchMigration {
 
     @Override
-    public void runMigration(RestHighLevelClient client, String indexPrefix) throws IOException {
+    public void runMigration(ElasticsearchClient client, String indexPrefix) throws IOException {
         final String backgroundJobServerIndexName = elementPrefixer(indexPrefix, DEFAULT_BACKGROUND_JOB_SERVER_INDEX_NAME);
         if (indexExists(client, backgroundJobServerIndexName))
             return; //why: to be compatible with existing installations not using Migrations yet
 
-        createIndex(client, backgroundJobServersIndex(backgroundJobServerIndexName));
+        createIndex(client, index(backgroundJobServerIndexName));
     }
 
-    private static CreateIndexRequest backgroundJobServersIndex(String backgroundJobServerIndexName) {
-        return new CreateIndexRequest(backgroundJobServerIndexName)
-                .mapping(mapping(
-                        (sb, map) -> {
-                            sb.append(StorageProviderUtils.BackgroundJobServers.FIELD_FIRST_HEARTBEAT);
-                            map.put("type", "date_nanos");
-                        },
-                        (sb, map) -> {
-                            sb.append(StorageProviderUtils.BackgroundJobServers.FIELD_LAST_HEARTBEAT);
-                            map.put("type", "date_nanos");
-                        }
-                ));
-    }
+  private static CreateIndexRequest index(String name) {
+    return new CreateIndexRequest.Builder()
+      .index(name)
+      .mappings(m -> m
+        .properties(FIELD_FIRST_HEARTBEAT, p -> p.dateNanos(d -> d))
+        .properties(FIELD_LAST_HEARTBEAT, p -> p.dateNanos(d -> d))
+      )
+      .build();
+  }
 }

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/M004_CreateJobStatsIndex.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/M004_CreateJobStatsIndex.java
@@ -1,13 +1,13 @@
 package org.jobrunr.storage.nosql.elasticsearch.migrations;
 
-import org.elasticsearch.client.RestHighLevelClient;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 
 import java.io.IOException;
 
 public class M004_CreateJobStatsIndex extends ElasticSearchMigration {
 
     @Override
-    public void runMigration(RestHighLevelClient restHighLevelClients, String indexPrefix) throws IOException {
+    public void runMigration(ElasticsearchClient client, String indexPrefix) throws IOException {
         //why: to be compatible with existing installations not using Migrations yet
     }
 }

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/M005_CreateMetadataIndexAndDropJobStatsIndex.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/M005_CreateMetadataIndexAndDropJobStatsIndex.java
@@ -1,19 +1,17 @@
 package org.jobrunr.storage.nosql.elasticsearch.migrations;
 
-import org.elasticsearch.action.get.GetRequest;
-import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.client.indices.CreateIndexRequest;
-import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.json.JsonXContent;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.GetResponse;
+import co.elastic.clients.elasticsearch.core.IndexRequest;
+import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
 import org.jobrunr.jobs.states.StateName;
-import org.jobrunr.storage.StorageException;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
+import static co.elastic.clients.elasticsearch._types.Refresh.True;
 import static org.jobrunr.storage.StorageProviderUtils.Metadata;
 import static org.jobrunr.storage.StorageProviderUtils.elementPrefixer;
 import static org.jobrunr.storage.nosql.elasticsearch.ElasticSearchStorageProvider.DEFAULT_METADATA_INDEX_NAME;
@@ -23,69 +21,60 @@ public class M005_CreateMetadataIndexAndDropJobStatsIndex extends ElasticSearchM
     public static final String JOBRUNR_JOB_STATS = "jobrunr_job_stats";
 
     @Override
-    public void runMigration(RestHighLevelClient client, String indexPrefix) throws IOException {
+    public void runMigration(ElasticsearchClient client, String indexPrefix) throws IOException {
         final String metadataIndexName = elementPrefixer(indexPrefix, DEFAULT_METADATA_INDEX_NAME);
         createIndex(client, metadataIndex(metadataIndexName));
 
         migrateExistingAllTimeSucceededFromJobStatsToMetadataAndDropJobStats(client, metadataIndexName);
     }
 
-    private void migrateExistingAllTimeSucceededFromJobStatsToMetadataAndDropJobStats(RestHighLevelClient client, String metadataIndexName) throws IOException {
+    private void migrateExistingAllTimeSucceededFromJobStatsToMetadataAndDropJobStats(
+      ElasticsearchClient client,
+      String metadataIndexName) throws IOException {
         long totalSucceededAmount = 0;
 
         if (indexExists(client, JOBRUNR_JOB_STATS)) {
-            GetResponse getResponse = client.get(new GetRequest(JOBRUNR_JOB_STATS, "job_stats"), RequestOptions.DEFAULT);
-            totalSucceededAmount = (int) getResponse.getSource().getOrDefault(StateName.SUCCEEDED.toString(), 0L);
+            GetResponse<Map> getResponse = client.get(
+              g -> g.index(JOBRUNR_JOB_STATS).id("job_stats"),
+              Map.class
+            );
+            totalSucceededAmount = (int) getResponse
+              .source()
+              .getOrDefault(StateName.SUCCEEDED.toString(), 0L);
             deleteIndex(client, JOBRUNR_JOB_STATS);
         }
 
-        client.index(jobStats(totalSucceededAmount, metadataIndexName), RequestOptions.DEFAULT);
+        client.index(jobStats(totalSucceededAmount, metadataIndexName));
     }
 
-    public static IndexRequest jobStats(long totalSucceededAmount, String metadataIndexName) {
-        try {
-            XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
-            builder.startObject();
-            builder.field(Metadata.FIELD_NAME, Metadata.STATS_NAME);
-            builder.field(Metadata.FIELD_OWNER, Metadata.STATS_OWNER);
-            builder.field(Metadata.FIELD_VALUE, totalSucceededAmount);
-            builder.field(Metadata.FIELD_CREATED_AT, Instant.now());
-            builder.field(Metadata.FIELD_UPDATED_AT, Instant.now());
-            builder.endObject();
-            return new IndexRequest(metadataIndexName)
-                    .id(Metadata.STATS_ID)
-                    .source(builder);
-        } catch (IOException e) {
-            throw new StorageException(e);
-        }
+    public static IndexRequest<Map<Object, Object>> jobStats(
+      final long totalSucceededAmount,
+      final String metadataIndexName) {
+        final Map<Object, Object> map = new LinkedHashMap<>();
+        map.put(Metadata.FIELD_NAME, Metadata.STATS_NAME);
+        map.put(Metadata.FIELD_OWNER, Metadata.STATS_OWNER);
+        map.put(Metadata.FIELD_VALUE, totalSucceededAmount);
+        map.put(Metadata.FIELD_CREATED_AT, Instant.now());
+        map.put(Metadata.FIELD_UPDATED_AT, Instant.now());
+        return IndexRequest.of(
+          i -> i
+            .index(metadataIndexName)
+            .id(Metadata.STATS_ID)
+            .document(map)
+            .refresh(True)
+        );
     }
 
-
-    private static CreateIndexRequest metadataIndex(String metadataIndexName) {
-        return new CreateIndexRequest(metadataIndexName)
-                .mapping(mapping(
-                        (sb, map) -> {
-                            sb.append(Metadata.FIELD_NAME);
-                            map.put("type", "keyword");
-                        },
-                        (sb, map) -> {
-                            sb.append(Metadata.FIELD_OWNER);
-                            map.put("type", "keyword");
-                        },
-                        (sb, map) -> {
-                            sb.append(Metadata.FIELD_VALUE);
-                            map.put("type", "text");
-                            map.put("index", false);
-                            map.put("store", true);
-                        },
-                        (sb, map) -> {
-                            sb.append(Metadata.FIELD_CREATED_AT);
-                            map.put("type", "date_nanos");
-                        },
-                        (sb, map) -> {
-                            sb.append(Metadata.FIELD_UPDATED_AT);
-                            map.put("type", "date_nanos");
-                        }
-                ));
+    private static CreateIndexRequest metadataIndex(String name) {
+        return new CreateIndexRequest.Builder()
+          .index(name)
+          .mappings(m -> m
+            .properties(Metadata.FIELD_NAME, p -> p.keyword(k -> k))
+            .properties(Metadata.FIELD_OWNER, p -> p.keyword(k -> k))
+            .properties(Metadata.FIELD_VALUE, p -> p.text(t -> t.index(false).store(true)))
+            .properties(Metadata.FIELD_CREATED_AT, p -> p.dateNanos(d -> d))
+            .properties(Metadata.FIELD_UPDATED_AT, p -> p.dateNanos(d -> d))
+          )
+          .build();
     }
 }

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/M005_CreateMetadataIndexAndDropJobStatsIndex.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/M005_CreateMetadataIndexAndDropJobStatsIndex.java
@@ -12,6 +12,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static co.elastic.clients.elasticsearch._types.Refresh.True;
+import static java.time.Instant.now;
 import static java.util.Optional.ofNullable;
 import static org.jobrunr.storage.StorageProviderUtils.Metadata;
 import static org.jobrunr.storage.StorageProviderUtils.elementPrefixer;
@@ -64,8 +65,9 @@ public class M005_CreateMetadataIndexAndDropJobStatsIndex extends ElasticSearchM
         map.put(Metadata.FIELD_NAME, Metadata.STATS_NAME);
         map.put(Metadata.FIELD_OWNER, Metadata.STATS_OWNER);
         map.put(Metadata.FIELD_VALUE, totalSucceededAmount);
-        map.put(Metadata.FIELD_CREATED_AT, Instant.now());
-        map.put(Metadata.FIELD_UPDATED_AT, Instant.now());
+        final Instant now = now();
+        map.put(Metadata.FIELD_CREATED_AT, now.toEpochMilli());
+        map.put(Metadata.FIELD_UPDATED_AT, now.toEpochMilli());
 
         return IndexRequest.of(
           i -> i

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/M005_CreateMetadataIndexAndDropJobStatsIndex.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/M005_CreateMetadataIndexAndDropJobStatsIndex.java
@@ -12,16 +12,22 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static co.elastic.clients.elasticsearch._types.Refresh.True;
+import static java.util.Optional.ofNullable;
 import static org.jobrunr.storage.StorageProviderUtils.Metadata;
 import static org.jobrunr.storage.StorageProviderUtils.elementPrefixer;
 import static org.jobrunr.storage.nosql.elasticsearch.ElasticSearchStorageProvider.DEFAULT_METADATA_INDEX_NAME;
 
 public class M005_CreateMetadataIndexAndDropJobStatsIndex extends ElasticSearchMigration {
+    @SuppressWarnings("unchecked")
+    private static final Class<Map<Object, Object>> MAP_CLASS = (Class<Map<Object, Object>>) Map.of().getClass();
 
     public static final String JOBRUNR_JOB_STATS = "jobrunr_job_stats";
 
     @Override
-    public void runMigration(ElasticsearchClient client, String indexPrefix) throws IOException {
+    public void runMigration(
+      final ElasticsearchClient client,
+      final String indexPrefix) throws IOException {
+
         final String metadataIndexName = elementPrefixer(indexPrefix, DEFAULT_METADATA_INDEX_NAME);
         createIndex(client, metadataIndex(metadataIndexName));
 
@@ -29,17 +35,19 @@ public class M005_CreateMetadataIndexAndDropJobStatsIndex extends ElasticSearchM
     }
 
     private void migrateExistingAllTimeSucceededFromJobStatsToMetadataAndDropJobStats(
-      ElasticsearchClient client,
-      String metadataIndexName) throws IOException {
+      final ElasticsearchClient client,
+      final String metadataIndexName) throws IOException {
+
         long totalSucceededAmount = 0;
 
         if (indexExists(client, JOBRUNR_JOB_STATS)) {
-            GetResponse<Map> getResponse = client.get(
+            final GetResponse<Map<Object, Object>> getResponse = client.get(
               g -> g.index(JOBRUNR_JOB_STATS).id("job_stats"),
-              Map.class
+              MAP_CLASS
             );
-            totalSucceededAmount = (int) getResponse
-              .source()
+
+            totalSucceededAmount = (int) ofNullable(getResponse.source())
+              .orElseGet(Map::of)
               .getOrDefault(StateName.SUCCEEDED.toString(), 0L);
             deleteIndex(client, JOBRUNR_JOB_STATS);
         }
@@ -50,12 +58,15 @@ public class M005_CreateMetadataIndexAndDropJobStatsIndex extends ElasticSearchM
     public static IndexRequest<Map<Object, Object>> jobStats(
       final long totalSucceededAmount,
       final String metadataIndexName) {
+
         final Map<Object, Object> map = new LinkedHashMap<>();
+
         map.put(Metadata.FIELD_NAME, Metadata.STATS_NAME);
         map.put(Metadata.FIELD_OWNER, Metadata.STATS_OWNER);
         map.put(Metadata.FIELD_VALUE, totalSucceededAmount);
         map.put(Metadata.FIELD_CREATED_AT, Instant.now());
         map.put(Metadata.FIELD_UPDATED_AT, Instant.now());
+
         return IndexRequest.of(
           i -> i
             .index(metadataIndexName)

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/M006_UpdateRecurringJobsIndex.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/migrations/M006_UpdateRecurringJobsIndex.java
@@ -1,32 +1,27 @@
 package org.jobrunr.storage.nosql.elasticsearch.migrations;
 
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.client.indices.PutMappingRequest;
-import org.jobrunr.storage.StorageProviderUtils.RecurringJobs;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.indices.PutMappingRequest;
 
 import java.io.IOException;
 
+import static org.jobrunr.storage.StorageProviderUtils.RecurringJobs.FIELD_CREATED_AT;
 import static org.jobrunr.storage.StorageProviderUtils.elementPrefixer;
 import static org.jobrunr.storage.nosql.elasticsearch.ElasticSearchStorageProvider.DEFAULT_RECURRING_JOB_INDEX_NAME;
 
 public class M006_UpdateRecurringJobsIndex  extends ElasticSearchMigration {
 
     @Override
-    public void runMigration(RestHighLevelClient client, String indexPrefix) throws IOException {
+    public void runMigration(ElasticsearchClient client, String indexPrefix) throws IOException {
         final String recurringJobIndexName = elementPrefixer(indexPrefix, DEFAULT_RECURRING_JOB_INDEX_NAME);
 
-        updateIndex(client, recurringJobIndex(recurringJobIndexName));
+        updateIndex(client, index(recurringJobIndexName));
     }
 
-    private static PutMappingRequest recurringJobIndex(String recurringJobIndexName) {
-        return new PutMappingRequest(recurringJobIndexName)
-                .source(mapping(
-                        (sb, map) -> {
-                            sb.append(RecurringJobs.FIELD_CREATED_AT);
-                            map.put("type", "long");
-                            map.put("index", false);
-                            map.put("store", true);
-                        }
-                ));
-    }
+  private static PutMappingRequest index(String name) {
+    return new PutMappingRequest.Builder()
+      .index(name)
+      .properties(FIELD_CREATED_AT, p -> p.long_(l -> l.index(false).store(true)))
+      .build();
+  }
 }

--- a/core/src/test/java/org/jobrunr/architecture/PackageDependenciesTest.java
+++ b/core/src/test/java/org/jobrunr/architecture/PackageDependenciesTest.java
@@ -103,7 +103,7 @@ class PackageDependenciesTest {
     ArchRule jobRunrStorageElasticSearchClassesDependenciesTest = classes()
             .that().resideInAPackage("org.jobrunr.storage.nosql.elasticsearch..")
             .should().onlyDependOnClassesThat(
-                    resideInAnyPackage("org.jobrunr.jobs..", "org.jobrunr.storage..", "org.jobrunr.utils..", "org.elasticsearch..", "org.apache.http..", "org.slf4j..", "java..")
+                    resideInAnyPackage("org.jobrunr.jobs..", "org.jobrunr.storage..", "org.jobrunr.utils..", "co.elastic...", "org.apache.http..", "org.slf4j..", "java..")
                             .or(are(equivalentTo(JobRunrException.class)))
             );
 

--- a/core/src/test/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDBCreatorTest.java
+++ b/core/src/test/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDBCreatorTest.java
@@ -23,6 +23,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
 
+import static java.util.Map.of;
 import static org.assertj.core.api.Assertions.*;
 
 @Testcontainers
@@ -31,7 +32,12 @@ import static org.assertj.core.api.Assertions.*;
 class ElasticSearchDBCreatorTest {
 
     @Container
-    private static final ElasticsearchContainer elasticSearchContainer = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.10.1").withExposedPorts(9200);
+    private static final ElasticsearchContainer elasticSearchContainer = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.17.8")
+      .withEnv(of(
+        "ES_JAVA_OPTS", "-Xmx512m",
+        "discovery.type", "single-node",
+        "xpack.security.enabled", "false"
+      )).withExposedPorts(9200);
 
     @Mock
     private ElasticSearchStorageProvider elasticSearchStorageProviderMock;

--- a/core/src/test/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDBCreatorTest.java
+++ b/core/src/test/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchDBCreatorTest.java
@@ -33,11 +33,8 @@ class ElasticSearchDBCreatorTest {
 
     @Container
     private static final ElasticsearchContainer elasticSearchContainer = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.17.8")
-      .withEnv(of(
-        "ES_JAVA_OPTS", "-Xmx512m",
-        "discovery.type", "single-node",
-        "xpack.security.enabled", "false"
-      )).withExposedPorts(9200);
+      .withEnv(of("ES_JAVA_OPTS", "-Xmx512m"))
+      .withExposedPorts(9200);
 
     @Mock
     private ElasticSearchStorageProvider elasticSearchStorageProviderMock;

--- a/core/src/test/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchStorageProviderTest.java
@@ -33,11 +33,8 @@ class ElasticSearchStorageProviderTest extends StorageProviderTest {
 
     @Container
     private static final ElasticsearchContainer elasticSearchContainer = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.17.8")
-      .withEnv(of(
-        "ES_JAVA_OPTS", "-Xmx512m",
-        "discovery.type", "single-node",
-        "xpack.security.enabled", "false"
-      )).withExposedPorts(9200);
+      .withEnv(of("ES_JAVA_OPTS", "-Xmx512m"))
+      .withExposedPorts(9200);
 
     private static ElasticsearchClient client;
 

--- a/core/src/test/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchStorageProviderTest.java
@@ -19,6 +19,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.io.IOException;
 import java.util.function.Function;
 
+import static java.util.Map.of;
 import static org.jobrunr.storage.StorageProviderUtils.DatabaseOptions.CREATE;
 import static org.jobrunr.utils.resilience.RateLimiter.Builder.rateLimit;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,7 +32,12 @@ import static org.mockito.internal.util.reflection.Whitebox.setInternalState;
 class ElasticSearchStorageProviderTest extends StorageProviderTest {
 
     @Container
-    private static final ElasticsearchContainer elasticSearchContainer = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.10.1").withExposedPorts(9200);
+    private static final ElasticsearchContainer elasticSearchContainer = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.17.8")
+      .withEnv(of(
+        "ES_JAVA_OPTS", "-Xmx512m",
+        "discovery.type", "single-node",
+        "xpack.security.enabled", "false"
+      )).withExposedPorts(9200);
 
     private static ElasticsearchClient client;
 

--- a/framework-support/jobrunr-micronaut-feature/build.gradle
+++ b/framework-support/jobrunr-micronaut-feature/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     compileOnly 'redis.clients:jedis'
     compileOnly 'io.lettuce:lettuce-core'
     compileOnly 'org.mongodb:mongodb-driver-sync'
-    compileOnly 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
+    compileOnly 'co.elastic.clients:elasticsearch-java'
     compileOnly 'io.micrometer:micrometer-core'
 
     testImplementation testFixtures(project(":core"))
@@ -37,7 +37,8 @@ dependencies {
     testImplementation 'redis.clients:jedis'
     testImplementation 'io.lettuce:lettuce-core'
     testImplementation 'org.mongodb:mongodb-driver-sync'
-    testImplementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
+    testImplementation 'co.elastic.clients:elasticsearch-java'
+
     testImplementation 'io.micrometer:micrometer-core'
 }
 

--- a/framework-support/jobrunr-micronaut-feature/src/test/java/org/jobrunr/micronaut/autoconfigure/storage/JobRunrElasticSearchStorageProviderFactoryTest.java
+++ b/framework-support/jobrunr-micronaut-feature/src/test/java/org/jobrunr/micronaut/autoconfigure/storage/JobRunrElasticSearchStorageProviderFactoryTest.java
@@ -1,15 +1,14 @@
 package org.jobrunr.micronaut.autoconfigure.storage;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.cluster.ElasticsearchClusterClient;
+import co.elastic.clients.elasticsearch.core.GetResponse;
+import co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesClient;
+import co.elastic.clients.elasticsearch.indices.ExistsRequest;
+import co.elastic.clients.transport.endpoints.BooleanResponse;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
-import org.elasticsearch.action.get.GetRequest;
-import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.client.ClusterClient;
-import org.elasticsearch.client.IndicesClient;
-import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.client.indices.GetIndexRequest;
 import org.jobrunr.storage.InMemoryStorageProvider;
 import org.jobrunr.storage.StorageProvider;
 import org.jobrunr.storage.nosql.elasticsearch.ElasticSearchStorageProvider;
@@ -17,10 +16,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.function.Function;
 
 import static org.jobrunr.micronaut.MicronautAssertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,29 +31,37 @@ class JobRunrElasticSearchStorageProviderFactoryTest {
 
     @BeforeEach
     void setupElasticSearchClient() throws IOException {
-        context.registerSingleton(elasticSearchRestHighLevelClient());
+        context.registerSingleton(elasticsearchClient());
     }
 
     @Test
     void elasticSearchStorageProviderAutoConfigurationTest() {
         assertThat(context).hasSingleBean(StorageProvider.class);
         assertThat(context.getBean(StorageProvider.class))
-                .isInstanceOf(ElasticSearchStorageProvider.class)
-                .hasJobMapper();
+          .isInstanceOf(ElasticSearchStorageProvider.class)
+          .hasJobMapper();
         assertThat(context).doesNotHaveBean(InMemoryStorageProvider.class);
     }
 
-    public RestHighLevelClient elasticSearchRestHighLevelClient() throws IOException {
-        RestHighLevelClient restHighLevelClientMock = mock(RestHighLevelClient.class);
-        IndicesClient indicesClientMock = mock(IndicesClient.class);
-        ClusterClient clusterClientMock = mock(ClusterClient.class);
-        when(restHighLevelClientMock.indices()).thenReturn(indicesClientMock);
-        when(restHighLevelClientMock.cluster()).thenReturn(clusterClientMock);
-        when(indicesClientMock.exists(any(GetIndexRequest.class), eq(RequestOptions.DEFAULT))).thenReturn(true);
+    public static ElasticsearchClient elasticsearchClient() throws IOException {
+        final ElasticsearchClient client = mock(ElasticsearchClient.class);
 
-        GetResponse getResponse = mock(GetResponse.class);
-        when(getResponse.isExists()).thenReturn(true);
-        when(restHighLevelClientMock.get(any(GetRequest.class), eq(RequestOptions.DEFAULT))).thenReturn(getResponse);
-        return restHighLevelClientMock;
+        final GetResponse<?> getResponse = mock(GetResponse.class);
+        when(getResponse.found()).thenReturn(true);
+        when(client.get(any(Function.class), any())).thenAnswer(args -> getResponse);
+
+        final BooleanResponse exists = new BooleanResponse(true);
+        when(client.exists(any(Function.class))).thenReturn(exists);
+
+        final ElasticsearchIndicesClient indices = mock(ElasticsearchIndicesClient.class);
+        when(client.indices()).thenReturn(indices);
+
+        when(indices.exists(any(Function.class))).thenReturn(exists);
+        when(indices.exists(any(ExistsRequest.class))).thenReturn(exists);
+
+        final ElasticsearchClusterClient cluster = mock(ElasticsearchClusterClient.class);
+        when(client.cluster()).thenReturn(cluster);
+
+        return client;
     }
 }

--- a/framework-support/jobrunr-micronaut-feature/src/test/java/org/jobrunr/micronaut/autoconfigure/storage/JobRunrMultipleStorageProviderFactoryTest.java
+++ b/framework-support/jobrunr-micronaut-feature/src/test/java/org/jobrunr/micronaut/autoconfigure/storage/JobRunrMultipleStorageProviderFactoryTest.java
@@ -5,13 +5,6 @@ import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
-import org.elasticsearch.action.get.GetRequest;
-import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.client.ClusterClient;
-import org.elasticsearch.client.IndicesClient;
-import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.client.indices.GetIndexRequest;
 import org.jobrunr.storage.InMemoryStorageProvider;
 import org.jobrunr.storage.StorageProvider;
 import org.jobrunr.storage.sql.SqlStorageProvider;
@@ -23,8 +16,7 @@ import java.io.IOException;
 import java.sql.*;
 
 import static org.jobrunr.micronaut.MicronautAssertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.jobrunr.micronaut.autoconfigure.storage.JobRunrElasticSearchStorageProviderFactoryTest.elasticsearchClient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -36,7 +28,7 @@ class JobRunrMultipleStorageProviderFactoryTest {
 
     @BeforeEach
     void setupDataSource() throws SQLException, IOException {
-        context.registerSingleton(elasticSearchRestHighLevelClient());
+        context.registerSingleton(elasticsearchClient());
         context.registerSingleton(dataSource());
     }
 
@@ -74,19 +66,4 @@ class JobRunrMultipleStorageProviderFactoryTest {
             when(resultSetMock.getInt(1)).thenReturn(1);
         }
     }
-
-    public RestHighLevelClient elasticSearchRestHighLevelClient() throws IOException {
-        RestHighLevelClient restHighLevelClientMock = mock(RestHighLevelClient.class);
-        IndicesClient indicesClientMock = mock(IndicesClient.class);
-        ClusterClient clusterClientMock = mock(ClusterClient.class);
-        when(restHighLevelClientMock.indices()).thenReturn(indicesClientMock);
-        when(restHighLevelClientMock.cluster()).thenReturn(clusterClientMock);
-        when(indicesClientMock.exists(any(GetIndexRequest.class), eq(RequestOptions.DEFAULT))).thenReturn(true);
-
-        GetResponse getResponse = mock(GetResponse.class);
-        when(getResponse.isExists()).thenReturn(true);
-        when(restHighLevelClientMock.get(any(GetRequest.class), eq(RequestOptions.DEFAULT))).thenReturn(getResponse);
-        return restHighLevelClientMock;
-    }
-
 }

--- a/framework-support/jobrunr-quarkus-extension/runtime/build.gradle
+++ b/framework-support/jobrunr-quarkus-extension/runtime/build.gradle
@@ -36,13 +36,13 @@ dependencies {
     compileOnly 'org.eclipse:yasson'
 
     compileOnly 'org.mongodb:mongodb-driver-sync'
-    compileOnly 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
+    compileOnly 'co.elastic.clients:elasticsearch-java'
 
     testImplementation testFixtures(project(":core"))
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'
     testImplementation 'org.eclipse:yasson'
     testImplementation 'org.mongodb:mongodb-driver-sync'
-    testImplementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
+    testImplementation 'co.elastic.clients:elasticsearch-java'
 }
 
 java {

--- a/framework-support/jobrunr-quarkus-extension/runtime/src/main/java/org/jobrunr/quarkus/autoconfigure/storage/JobRunrElasticSearchStorageProviderProducer.java
+++ b/framework-support/jobrunr-quarkus-extension/runtime/src/main/java/org/jobrunr/quarkus/autoconfigure/storage/JobRunrElasticSearchStorageProviderProducer.java
@@ -1,7 +1,7 @@
 package org.jobrunr.quarkus.autoconfigure.storage;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import io.quarkus.arc.DefaultBean;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.jobrunr.jobs.mappers.JobMapper;
 import org.jobrunr.quarkus.autoconfigure.JobRunrConfiguration;
 import org.jobrunr.storage.StorageProvider;
@@ -16,13 +16,18 @@ public class JobRunrElasticSearchStorageProviderProducer {
     @Produces
     @DefaultBean
     @Singleton
-    public StorageProvider storageProvider(RestHighLevelClient restHighLevelClient, JobMapper jobMapper, JobRunrConfiguration configuration) {
-        if(configuration.database.type.isPresent() && !configuration.database.type.get().equalsIgnoreCase("elasticsearch")) return null;
+    public StorageProvider storageProvider(
+      final ElasticsearchClient client,
+      final JobMapper jobMapper,
+      final JobRunrConfiguration configuration) {
 
-        String tablePrefix = configuration.database.tablePrefix.orElse(null);
-        DatabaseOptions databaseOptions = configuration.database.skipCreate ? DatabaseOptions.SKIP_CREATE : DatabaseOptions.CREATE;
-        ElasticSearchStorageProvider elasticSearchStorageProvider = new ElasticSearchStorageProvider(restHighLevelClient, tablePrefix, databaseOptions);
-        elasticSearchStorageProvider.setJobMapper(jobMapper);
-        return elasticSearchStorageProvider;
+        if (configuration.database.type.isPresent() && !configuration.database.type.get().equalsIgnoreCase("elasticsearch")) return null;
+
+        final String tableprefix = configuration.database.tablePrefix.orElse(null);
+        final DatabaseOptions options = configuration.database.skipCreate ? DatabaseOptions.SKIP_CREATE : DatabaseOptions.CREATE;
+        final ElasticSearchStorageProvider provider = new ElasticSearchStorageProvider(client, tableprefix, options);
+        provider.setJobMapper(jobMapper);
+
+        return provider;
     }
 }

--- a/framework-support/jobrunr-spring-boot-starter/build.gradle
+++ b/framework-support/jobrunr-spring-boot-starter/build.gradle
@@ -8,8 +8,8 @@ plugins {
 
 dependencies {
     api platform(project(':platform'))
-    api platform('org.springframework.boot:spring-boot-dependencies:2.7.4')
-    annotationProcessor platform('org.springframework.boot:spring-boot-dependencies:2.7.4')
+    api platform('org.springframework.boot:spring-boot-dependencies:2.7.7')
+    annotationProcessor platform('org.springframework.boot:spring-boot-dependencies:2.7.7')
     api project(':core')
 
     api 'org.springframework.boot:spring-boot-starter'

--- a/framework-support/jobrunr-spring-boot-starter/build.gradle
+++ b/framework-support/jobrunr-spring-boot-starter/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compileOnly 'redis.clients:jedis'
     compileOnly 'io.lettuce:lettuce-core'
     compileOnly 'org.mongodb:mongodb-driver-sync'
-    compileOnly 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
+    compileOnly 'co.elastic.clients:elasticsearch-java'
 
     testImplementation testFixtures(project(":core"))
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -35,7 +35,7 @@ dependencies {
     testImplementation 'redis.clients:jedis'
     testImplementation 'io.lettuce:lettuce-core'
     testImplementation 'org.mongodb:mongodb-driver-sync'
-    testImplementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
+    testImplementation 'co.elastic.clients:elasticsearch-java'
     testImplementation 'io.micrometer:micrometer-core'
 }
 

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -37,7 +37,7 @@ dependencies {
         api 'redis.clients:jedis:4.2.3'
         api 'io.lettuce:lettuce-core:6.2.0.RELEASE'
         api 'org.mongodb:mongodb-driver-sync:4.7.1'
-        api 'org.elasticsearch.client:elasticsearch-rest-high-level-client:7.17.6'
+        api 'co.elastic.clients:elasticsearch-java:7.17.8'
 
         api 'org.junit.jupiter:junit-jupiter:5.9.1'
         api 'io.github.artsok:rerunner-jupiter:2.1.6'

--- a/tests/e2e-elasticsearch-gson/build.gradle
+++ b/tests/e2e-elasticsearch-gson/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation project(':tests:e2e-base')
     implementation 'org.slf4j:slf4j-simple'
     implementation 'com.google.code.gson:gson'
-    implementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
+    implementation 'co.elastic.clients:elasticsearch-java'
 
     testImplementation project(':core')
     testImplementation testFixtures(project(":tests:e2e-base"))

--- a/tests/e2e-elasticsearch-gson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchGsonBackgroundJobContainer.java
+++ b/tests/e2e-elasticsearch-gson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchGsonBackgroundJobContainer.java
@@ -2,12 +2,12 @@ package org.jobrunr.tests.e2e;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.json.SimpleJsonpMapper;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
 import org.jobrunr.storage.StorageProvider;
 import org.jobrunr.storage.nosql.elasticsearch.ElasticSearchStorageProvider;
-import org.jobrunr.utils.mapper.gson.GsonJsonMapper;
 import org.testcontainers.containers.Network;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
@@ -41,7 +41,7 @@ public class ElasticSearchGsonBackgroundJobContainer extends AbstractBackgroundJ
           .setRequestConfigCallback(b -> b.setSocketTimeout(100 * 1000))
           .build();
 
-        final RestClientTransport transport = new RestClientTransport(restClient, new SimpleJsonpMapper());
+        final RestClientTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
         final ElasticsearchClient restHighLevelClient = new ElasticsearchClient(transport);
 
         return new ElasticSearchStorageProvider(restHighLevelClient);

--- a/tests/e2e-elasticsearch-gson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchGsonE2ETest.java
+++ b/tests/e2e-elasticsearch-gson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchGsonE2ETest.java
@@ -19,11 +19,8 @@ public class ElasticSearchGsonE2ETest extends AbstractE2EGsonTest {
     private static final ElasticsearchContainer elasticSearchContainer = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.17.8")
       .withNetwork(network)
       .withNetworkAliases("elasticsearch")
-      .withEnv(of(
-        "ES_JAVA_OPTS", "-Xmx512m",
-        "discovery.type", "single-node",
-        "xpack.security.enabled", "false"
-      )).withExposedPorts(9200);
+      .withEnv(of("ES_JAVA_OPTS", "-Xmx512m"))
+      .withExposedPorts(9200);
 
     @Container
     private static final ElasticSearchGsonBackgroundJobContainer backgroundJobServer = new ElasticSearchGsonBackgroundJobContainer(elasticSearchContainer, network);

--- a/tests/e2e-elasticsearch-gson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchGsonE2ETest.java
+++ b/tests/e2e-elasticsearch-gson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchGsonE2ETest.java
@@ -7,6 +7,8 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import static java.util.Map.of;
+
 @Testcontainers
 @Disabled("My NAS only has 8GB of RAM which is not enough for Elastic and thus this test is flaky")
 public class ElasticSearchGsonE2ETest extends AbstractE2EGsonTest {
@@ -14,10 +16,14 @@ public class ElasticSearchGsonE2ETest extends AbstractE2EGsonTest {
     private static final Network network = Network.newNetwork();
 
     @Container
-    private static final ElasticsearchContainer elasticSearchContainer = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.10.1")
-            .withNetwork(network)
-            .withNetworkAliases("elasticsearch")
-            .withExposedPorts(9200);
+    private static final ElasticsearchContainer elasticSearchContainer = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.17.8")
+      .withNetwork(network)
+      .withNetworkAliases("elasticsearch")
+      .withEnv(of(
+        "ES_JAVA_OPTS", "-Xmx512m",
+        "discovery.type", "single-node",
+        "xpack.security.enabled", "false"
+      )).withExposedPorts(9200);
 
     @Container
     private static final ElasticSearchGsonBackgroundJobContainer backgroundJobServer = new ElasticSearchGsonBackgroundJobContainer(elasticSearchContainer, network);

--- a/tests/e2e-elasticsearch-jackson/build.gradle
+++ b/tests/e2e-elasticsearch-jackson/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation project(':tests:e2e-base')
     implementation 'org.slf4j:slf4j-simple'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    implementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
+    implementation 'co.elastic.clients:elasticsearch-java'
 
     testImplementation project(':core')
     testImplementation testFixtures(project(":tests:e2e-base"))

--- a/tests/e2e-elasticsearch-jackson/build.gradle
+++ b/tests/e2e-elasticsearch-jackson/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation project(':tests:e2e-base')
     implementation 'org.slf4j:slf4j-simple'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'co.elastic.clients:elasticsearch-java'
 
     testImplementation project(':core')

--- a/tests/e2e-elasticsearch-jackson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchJacksonBackgroundJobContainer.java
+++ b/tests/e2e-elasticsearch-jackson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchJacksonBackgroundJobContainer.java
@@ -1,8 +1,10 @@
 package org.jobrunr.tests.e2e;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.SimpleJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.jobrunr.storage.StorageProvider;
 import org.jobrunr.storage.nosql.elasticsearch.ElasticSearchStorageProvider;
 import org.testcontainers.containers.Network;
@@ -32,8 +34,15 @@ public class ElasticSearchJacksonBackgroundJobContainer extends AbstractBackgrou
 
     @Override
     public StorageProvider getStorageProviderForClient() {
-        HttpHost httpHost = new HttpHost(elasticSearchContainer.getHost(), elasticSearchContainer.getFirstMappedPort(), "http");
-        RestHighLevelClient restHighLevelClient = new RestHighLevelClient(RestClient.builder(httpHost).setRequestConfigCallback(requestConfigBuilder -> requestConfigBuilder.setSocketTimeout(100 * 1000)));
+        final HttpHost httpHost = new HttpHost(elasticSearchContainer.getHost(), elasticSearchContainer.getFirstMappedPort(), "http");
+        final RestClient restClient = RestClient
+          .builder(httpHost)
+          .setRequestConfigCallback(b -> b.setSocketTimeout(100 * 1000))
+          .build();
+
+        final RestClientTransport transport = new RestClientTransport(restClient, new SimpleJsonpMapper());
+        final ElasticsearchClient restHighLevelClient = new ElasticsearchClient(transport);
+
         return new ElasticSearchStorageProvider(restHighLevelClient);
     }
 

--- a/tests/e2e-elasticsearch-jackson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchJacksonBackgroundJobContainer.java
+++ b/tests/e2e-elasticsearch-jackson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchJacksonBackgroundJobContainer.java
@@ -1,8 +1,10 @@
 package org.jobrunr.tests.e2e;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.json.SimpleJsonpMapper;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
 import org.jobrunr.storage.StorageProvider;
@@ -40,7 +42,11 @@ public class ElasticSearchJacksonBackgroundJobContainer extends AbstractBackgrou
           .setRequestConfigCallback(b -> b.setSocketTimeout(100 * 1000))
           .build();
 
-        final RestClientTransport transport = new RestClientTransport(restClient, new SimpleJsonpMapper());
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.findAndRegisterModules();
+
+        final RestClientTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper(mapper));
         final ElasticsearchClient restHighLevelClient = new ElasticsearchClient(transport);
 
         return new ElasticSearchStorageProvider(restHighLevelClient);

--- a/tests/e2e-elasticsearch-jackson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchJacksonE2ETest.java
+++ b/tests/e2e-elasticsearch-jackson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchJacksonE2ETest.java
@@ -7,17 +7,20 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.util.Map;
+
 @Testcontainers
-@Disabled("My NAS only has 8GB of RAM which is not enough for Elastic and thus this test is flaky")
+// @Disabled("My NAS only has 8GB of RAM which is not enough for Elastic and thus this test is flaky")
 public class ElasticSearchJacksonE2ETest extends AbstractE2EJacksonTest {
 
     private static final Network network = Network.newNetwork();
 
     @Container
-    private static final ElasticsearchContainer elasticSearchContainer = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.10.1")
-            .withNetwork(network)
-            .withNetworkAliases("elasticsearch")
-            .withExposedPorts(9200);
+    private static final ElasticsearchContainer elasticSearchContainer = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.17.8")
+      .withNetwork(network)
+      .withNetworkAliases("elasticsearch")
+      .withEnv(Map.of("ES_JAVA_OPTS", "-Xmx512m"))
+      .withExposedPorts(9200);
 
     @Container
     private static final ElasticSearchJacksonBackgroundJobContainer backgroundJobServer = new ElasticSearchJacksonBackgroundJobContainer(elasticSearchContainer, network);

--- a/tests/e2e-elasticsearch-jackson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchJacksonE2ETest.java
+++ b/tests/e2e-elasticsearch-jackson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchJacksonE2ETest.java
@@ -1,6 +1,7 @@
 package org.jobrunr.tests.e2e;
 
 import org.jobrunr.storage.StorageProvider;
+import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.Network;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -17,14 +18,12 @@ public class ElasticSearchJacksonE2ETest extends AbstractE2EJacksonTest {
     private static final ElasticsearchContainer elasticSearchContainer = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.17.8")
       .withNetwork(network)
       .withNetworkAliases("elasticsearch")
-      .withEnv(of(
-        "network.host", "0.0.0.0",
-        "xpack.security.enabled", "false",
-        "ES_JAVA_OPTS", "-Xmx512m"
-        )).withExposedPorts(9200);
+      .withEnv(of("ES_JAVA_OPTS", "-Xmx1024m"))
+      .withExposedPorts(9200);
 
     @Container
     private static final ElasticSearchJacksonBackgroundJobContainer backgroundJobServer = new ElasticSearchJacksonBackgroundJobContainer(elasticSearchContainer, network);
+
 
     @Override
     protected StorageProvider getStorageProviderForClient() {

--- a/tests/e2e-elasticsearch-jackson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchJacksonE2ETest.java
+++ b/tests/e2e-elasticsearch-jackson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchJacksonE2ETest.java
@@ -1,16 +1,14 @@
 package org.jobrunr.tests.e2e;
 
 import org.jobrunr.storage.StorageProvider;
-import org.junit.jupiter.api.Disabled;
 import org.testcontainers.containers.Network;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.util.Map;
+import static java.util.Map.of;
 
 @Testcontainers
-// @Disabled("My NAS only has 8GB of RAM which is not enough for Elastic and thus this test is flaky")
 public class ElasticSearchJacksonE2ETest extends AbstractE2EJacksonTest {
 
     private static final Network network = Network.newNetwork();
@@ -19,8 +17,11 @@ public class ElasticSearchJacksonE2ETest extends AbstractE2EJacksonTest {
     private static final ElasticsearchContainer elasticSearchContainer = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.17.8")
       .withNetwork(network)
       .withNetworkAliases("elasticsearch")
-      .withEnv(Map.of("ES_JAVA_OPTS", "-Xmx512m"))
-      .withExposedPorts(9200);
+      .withEnv(of(
+        "network.host", "0.0.0.0",
+        "xpack.security.enabled", "false",
+        "ES_JAVA_OPTS", "-Xmx512m"
+        )).withExposedPorts(9200);
 
     @Container
     private static final ElasticSearchJacksonBackgroundJobContainer backgroundJobServer = new ElasticSearchJacksonBackgroundJobContainer(elasticSearchContainer, network);

--- a/tests/e2e-elasticsearch-jackson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchJacksonE2ETest.java
+++ b/tests/e2e-elasticsearch-jackson/src/test/java/org/jobrunr/tests/e2e/ElasticSearchJacksonE2ETest.java
@@ -2,6 +2,7 @@ package org.jobrunr.tests.e2e;
 
 import org.jobrunr.storage.StorageProvider;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.testcontainers.containers.Network;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -10,6 +11,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import static java.util.Map.of;
 
 @Testcontainers
+@Disabled("My NAS only has 8GB of RAM which is not enough for Elastic and thus this test is flaky")
 public class ElasticSearchJacksonE2ETest extends AbstractE2EJacksonTest {
 
     private static final Network network = Network.newNetwork();

--- a/tests/e2e-vm-jdk/build.gradle
+++ b/tests/e2e-vm-jdk/build.gradle
@@ -5,13 +5,13 @@ repositories {
 }
 
 compileJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 dependencies {


### PR DESCRIPTION
Hi,

I've spent a few days rewriting the Elasticsearch Storage Provider to use the new Elasticsearch client (as RestHighLevelClient is removed from Elasticsearch 8.x, see https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-high.html).

Other considerations:
- I had to switch to at least java 11 for source and target compatibility otherwise the project wouldn't build on my computer at all (have only Java 17 installed), see build.gradle:

```scala
    sourceCompatibility = JavaVersion.VERSION_11
    targetCompatibility = JavaVersion.VERSION_11
```

So far, i'm facing issues to make junit tests run correctly without any error. I'm trying to run `ElasticSearchJacksonE2ETest`, which fails with Jackson being unable to deserialize the `Job` from json:

```
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of `org.jobrunr.jobs.Job` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ...
```

Let me know how we can proceed to integrate those changes into your codebase :)