### PR TITLE
Update Spring Boot 3 autoconfiguration

### DIFF
--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
@@ -23,6 +23,7 @@ import org.jobrunr.utils.mapper.jsonb.JsonbJsonMapper;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.*;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.properties.PropertyMapper;
@@ -41,7 +42,7 @@ import static org.jobrunr.utils.reflection.ReflectionUtils.newInstance;
  * A Spring Boot AutoConfiguration class for JobRunr
  */
 @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
-@Configuration
+@AutoConfiguration
 @EnableConfigurationProperties(JobRunrProperties.class)
 @ComponentScan(basePackages = {"org.jobrunr.scheduling"})
 public class JobRunrAutoConfiguration {

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
@@ -164,7 +164,6 @@ public class JobRunrAutoConfiguration {
         }
     }
 
-    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     @Configuration
     @ConditionalOnClass(HealthIndicator.class)
     @ConditionalOnEnabledHealthIndicator("jobrunr")

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/metrics/JobRunrMetricsAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/metrics/JobRunrMetricsAutoConfiguration.java
@@ -9,15 +9,13 @@ import org.jobrunr.storage.StorageProvider;
 import org.jobrunr.storage.metrics.StorageProviderMetricsBinder;
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
-@AutoConfigureAfter({JobRunrAutoConfiguration.class, MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
+@AutoConfiguration(after = {JobRunrAutoConfiguration.class, MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @ConditionalOnClass(Metrics.class)
 @ConditionalOnBean({MeterRegistry.class})
 public class JobRunrMetricsAutoConfiguration {

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrDocumentDBStorageAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrDocumentDBStorageAutoConfiguration.java
@@ -6,17 +6,15 @@ import org.jobrunr.spring.autoconfigure.JobRunrProperties;
 import org.jobrunr.storage.StorageProvider;
 import org.jobrunr.storage.StorageProviderUtils.DatabaseOptions;
 import org.jobrunr.storage.nosql.documentdb.AmazonDocumentDBStorageProvider;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
+@AutoConfiguration(after = MongoAutoConfiguration.class)
 @ConditionalOnBean(MongoClient.class)
-@AutoConfigureAfter(MongoAutoConfiguration.class)
 @ConditionalOnProperty(prefix = "org.jobrunr.database", name = "type", havingValue = "documentdb", matchIfMissing = false)
 public class JobRunrDocumentDBStorageAutoConfiguration {
 

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrElasticSearchStorageAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrElasticSearchStorageAutoConfiguration.java
@@ -6,17 +6,15 @@ import org.jobrunr.spring.autoconfigure.JobRunrProperties;
 import org.jobrunr.storage.StorageProvider;
 import org.jobrunr.storage.StorageProviderUtils;
 import org.jobrunr.storage.nosql.elasticsearch.ElasticSearchStorageProvider;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
+@AutoConfiguration(after = ElasticsearchRestClientAutoConfiguration.class)
 @ConditionalOnBean(RestHighLevelClient.class)
-@AutoConfigureAfter(ElasticsearchRestClientAutoConfiguration.class)
 @ConditionalOnProperty(prefix = "org.jobrunr.database", name = "type", havingValue = "elasticsearch", matchIfMissing = true)
 public class JobRunrElasticSearchStorageAutoConfiguration {
 

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrJedisStorageAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrJedisStorageAutoConfiguration.java
@@ -4,14 +4,14 @@ import org.jobrunr.jobs.mappers.JobMapper;
 import org.jobrunr.spring.autoconfigure.JobRunrProperties;
 import org.jobrunr.storage.StorageProvider;
 import org.jobrunr.storage.nosql.redis.JedisRedisStorageProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import redis.clients.jedis.JedisPool;
 
-@Configuration
+@AutoConfiguration
 @ConditionalOnBean(JedisPool.class)
 @ConditionalOnProperty(prefix = "org.jobrunr.database", name = "type", havingValue = "redis-jedis", matchIfMissing = true)
 public class JobRunrJedisStorageAutoConfiguration {

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrLettuceStorageAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrLettuceStorageAutoConfiguration.java
@@ -5,13 +5,13 @@ import org.jobrunr.jobs.mappers.JobMapper;
 import org.jobrunr.spring.autoconfigure.JobRunrProperties;
 import org.jobrunr.storage.StorageProvider;
 import org.jobrunr.storage.nosql.redis.LettuceRedisStorageProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
+@AutoConfiguration
 @ConditionalOnBean(RedisClient.class)
 @ConditionalOnProperty(prefix = "org.jobrunr.database", name = "type", havingValue = "redis-lettuce", matchIfMissing = true)
 public class JobRunrLettuceStorageAutoConfiguration {

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrMongoDBStorageAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrMongoDBStorageAutoConfiguration.java
@@ -6,17 +6,15 @@ import org.jobrunr.spring.autoconfigure.JobRunrProperties;
 import org.jobrunr.storage.StorageProvider;
 import org.jobrunr.storage.StorageProviderUtils.DatabaseOptions;
 import org.jobrunr.storage.nosql.mongo.MongoDBStorageProvider;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
+@AutoConfiguration(after = MongoAutoConfiguration.class)
 @ConditionalOnBean(MongoClient.class)
-@AutoConfigureAfter(MongoAutoConfiguration.class)
 @ConditionalOnProperty(prefix = "org.jobrunr.database", name = "type", havingValue = "mongodb", matchIfMissing = true)
 public class JobRunrMongoDBStorageAutoConfiguration {
 

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrSqlStorageAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrSqlStorageAutoConfiguration.java
@@ -6,22 +6,20 @@ import org.jobrunr.storage.StorageProvider;
 import org.jobrunr.storage.StorageProviderUtils.DatabaseOptions;
 import org.jobrunr.storage.sql.common.SqlStorageProviderFactory;
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitialization;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 import javax.sql.DataSource;
 
 import static org.jobrunr.utils.StringUtils.isNotNullOrEmpty;
 
-@Configuration
+@AutoConfiguration(after = DataSourceAutoConfiguration.class)
 @ConditionalOnBean(DataSource.class)
-@AutoConfigureAfter(DataSourceAutoConfiguration.class)
 @ConditionalOnProperty(prefix = "org.jobrunr.database", name = "type", havingValue = "sql", matchIfMissing = true)
 public class JobRunrSqlStorageAutoConfiguration {
 

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/resources/META-INF/spring.factories
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/resources/META-INF/spring.factories
@@ -1,7 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.jobrunr.spring.autoconfigure.JobRunrAutoConfiguration,\
-  org.jobrunr.spring.autoconfigure.storage.JobRunrElasticSearchStorageAutoConfiguration,\
-  org.jobrunr.spring.autoconfigure.storage.JobRunrJedisStorageAutoConfiguration,\
-  org.jobrunr.spring.autoconfigure.storage.JobRunrLettuceStorageAutoConfiguration,\
-  org.jobrunr.spring.autoconfigure.storage.JobRunrMongoDBStorageAutoConfiguration,\
-  org.jobrunr.spring.autoconfigure.storage.JobRunrSqlStorageAutoConfiguration, \
-  org.jobrunr.spring.autoconfigure.metrics.JobRunrMetricsAutoConfiguration


### PR DESCRIPTION
This PR updates the current Spring Boot 3 auto configuration to use `@AutoConfigiguration` as recommended in the release notes (https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#new-autoconfiguration-annotation) and removes the unneeded `spring.factories` (https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#auto-configuration-files)