### PR TITLE
[Quarkus] Fix metrics producer being added unconditionally

### DIFF
--- a/framework-support/jobrunr-quarkus-extension/deployment/src/main/java/org/jobrunr/quarkus/extension/deployment/JobRunrExtensionProcessor.java
+++ b/framework-support/jobrunr-quarkus-extension/deployment/src/main/java/org/jobrunr/quarkus/extension/deployment/JobRunrExtensionProcessor.java
@@ -84,7 +84,6 @@ class JobRunrExtensionProcessor {
         additionalBeans.add(JobRunrProducer.class);
         additionalBeans.add(JobRunrStarter.class);
         additionalBeans.add(jsonMapper(capabilities));
-        additionalBeans.add(JobRunrMetricsProducer.StorageProviderMetricsProducer.class);
         additionalBeans.addAll(storageProvider(capabilities, jobRunrConfiguration));
 
         return AdditionalBeanBuildItem.builder()

--- a/framework-support/jobrunr-quarkus-extension/deployment/src/test/java/org/jobrunr/quarkus/extension/deployment/JobRunrExtensionProcessorTest.java
+++ b/framework-support/jobrunr-quarkus-extension/deployment/src/test/java/org/jobrunr/quarkus/extension/deployment/JobRunrExtensionProcessorTest.java
@@ -61,10 +61,12 @@ class JobRunrExtensionProcessorTest {
         final AdditionalBeanBuildItem additionalBeanBuildItem = jobRunrExtensionProcessor.produce(capabilities, jobRunrConfiguration);
 
         assertThat(additionalBeanBuildItem.getBeanClasses())
-                .contains(JobRunrProducer.class.getName())
-                .contains(JobRunrStarter.class.getName())
-                .contains(JobRunrInMemoryStorageProviderProducer.class.getName())
-                .contains(JobRunrProducer.JobRunrJsonBJsonMapperProducer.class.getName());
+                .containsOnly(
+                        JobRunrProducer.class.getName(),
+                        JobRunrStarter.class.getName(),
+                        JobRunrInMemoryStorageProviderProducer.class.getName(),
+                        JobRunrProducer.JobRunrJsonBJsonMapperProducer.class.getName()
+                );
     }
 
     @Test


### PR DESCRIPTION
This PR fixes an issue where `JobRunrMetricsProducer.StorageProviderMetricsProducer` was always added to the application beans. As a consequence, it was impossible to use the quarkus extension without the `quarkus-micrometer` extension.