### PR TITLE
make database migrations work on jboss/wildfly Fixes #383

### DIFF
--- a/core/src/main/java/org/jobrunr/utils/resources/VfsFilesystemProvider.java
+++ b/core/src/main/java/org/jobrunr/utils/resources/VfsFilesystemProvider.java
@@ -1,0 +1,39 @@
+package org.jobrunr.utils.resources;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
+
+public class VfsFilesystemProvider extends org.jobrunr.utils.resources.PathFileSystemProvider {
+
+    public static final String SCHEME = "vfs://";
+    private final Set<Path> extractedFiles;
+
+    public VfsFilesystemProvider() {
+        this.extractedFiles = new HashSet<>();
+    }
+
+    @Override
+    public Path toPath(URI uri) throws IOException {
+        uri = URI.create(uri.toString().substring(SCHEME.length()));
+        Path path =  super.toPath(uri);
+        extractedFiles.add(path);
+        return path;
+    }
+
+    @Override
+    public void close() throws IOException {
+        for (Path path : extractedFiles) {
+            Files.walk(path)
+                    .sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(File::delete);
+        }
+        super.close();
+    }
+}


### PR DESCRIPTION
As Jboss/Wildfly creates URLs with scheme vfs:// when accessing the database migration scripts stored in a jar inside WEB-INF, I added a FilesystemProvider which can handle this. 
The files get unpacked by the ClassRessourceProvider and deleted by the FilesystemProvider after usage.