### PR TITLE
Upgrade to Quarkus 3.5

### DIFF
--- a/framework-support/jobrunr-quarkus-extension/deployment/build.gradle
+++ b/framework-support/jobrunr-quarkus-extension/deployment/build.gradle
@@ -19,8 +19,8 @@ compileTestJava {
 
 dependencies {
     api platform(project(':platform'))
-    api platform('io.quarkus:quarkus-bom:3.4.3')
-    annotationProcessor 'io.quarkus:quarkus-extension-processor:3.4.3'
+    api platform('io.quarkus:quarkus-bom:3.5.3')
+    annotationProcessor 'io.quarkus:quarkus-extension-processor:3.5.3'
 
     api project(':core')
     api project(':framework-support:jobrunr-quarkus-extension:runtime')

--- a/framework-support/jobrunr-quarkus-extension/runtime/build.gradle
+++ b/framework-support/jobrunr-quarkus-extension/runtime/build.gradle
@@ -33,12 +33,13 @@ java {
 
 dependencies {
     api platform(project(':platform'))
-    api platform('io.quarkus:quarkus-bom:3.4.3')
-    annotationProcessor 'io.quarkus:quarkus-extension-processor:3.4.3'
+    api platform('io.quarkus:quarkus-bom:3.5.3')
+    annotationProcessor 'io.quarkus:quarkus-extension-processor:3.5.3'
 
     api project(':core')
     implementation 'io.quarkus:quarkus-core'
     implementation 'io.quarkus:quarkus-arc'
+    compileOnly 'org.graalvm.sdk:graal-sdk'
     compileOnly 'io.quarkus:quarkus-micrometer'
 
     metricsApi 'io.quarkus:quarkus-smallrye-health'

--- a/framework-support/jobrunr-quarkus-extension/runtime/src/main/java/org/jobrunr/scheduling/JobRunrRecurringJobRecorder.java
+++ b/framework-support/jobrunr-quarkus-extension/runtime/src/main/java/org/jobrunr/scheduling/JobRunrRecurringJobRecorder.java
@@ -27,7 +27,7 @@ public class JobRunrRecurringJobRecorder {
     private static final Logger LOGGER = Logger.getLogger(JobRunrRecurringJobRecorder.class);
 
     public void schedule(BeanContainer container, String id, String cron, String interval, String zoneId, String className, String methodName, List<JobParameter> parameterList) {
-        JobScheduler scheduler = container.instance(JobScheduler.class);
+        JobScheduler scheduler = container.beanInstance(JobScheduler.class);
         String jobId = getId(id);
         String optionalCronExpression = getCronExpression(cron);
         String optionalInterval = getInterval(interval);

--- a/framework-support/jobrunr-quarkus-extension/runtime/src/test/java/org/jobrunr/scheduling/JobRunrRecurringJobRecorderTest.java
+++ b/framework-support/jobrunr-quarkus-extension/runtime/src/test/java/org/jobrunr/scheduling/JobRunrRecurringJobRecorderTest.java
@@ -47,7 +47,7 @@ class JobRunrRecurringJobRecorderTest {
     @BeforeEach
     void setUpJobRunrRecorder() {
         jobRunrRecurringJobRecorder = new JobRunrRecurringJobRecorder();
-        when(beanContainer.instance(JobScheduler.class)).thenReturn(jobScheduler);
+        when(beanContainer.beanInstance(JobScheduler.class)).thenReturn(jobScheduler);
 
         ConfigProviderResolver.setInstance(configProviderResolver);
         when(configProviderResolver.getConfig()).thenReturn(config);

--- a/framework-support/jobrunr-quarkus-extension/tests/build.gradle
+++ b/framework-support/jobrunr-quarkus-extension/tests/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'io.quarkus' version '3.4.3'
+    id 'io.quarkus' version '3.5.3'
 }
 
 compileJava {
@@ -11,7 +11,7 @@ compileJava {
 
 dependencies {
     api platform(project(':platform'))
-    api platform('io.quarkus:quarkus-bom:3.4.3')
+    api platform('io.quarkus:quarkus-bom:3.5.3')
 
     api project(':framework-support:jobrunr-quarkus-extension:runtime')
     api project(':framework-support:jobrunr-quarkus-extension:deployment')


### PR DESCRIPTION
Hi @rdehuyss ,

Yet another Quarkus PR ;-) And it's another critical one for my projet.

There have been a breaking change in Quarkus that make the extension crashing with Quarkus >= 3.5.x. A deprecated method has beean deleted on the BeanContainer API : https://github.com/quarkusio/quarkus/pull/35776/commits/4f2aa80a0866ce827bcf114ce5fccb6dcf4379e5

Also, the elasticsearch-high-level-client extension has been deleted (since 3.3.x), so the capability constant is not available anymore : https://github.com/quarkusio/quarkus/commit/80139bcb631c632128873142abd9ba3b9a8f6956.

I tested it with success against quarkus 3.2.6 and 3.5.1 using MongoDB as a database. But I didn't succed to test the Elasticsearch integration, it seems to be already broken with the latest jobrunr version.