### PR TITLE
feat : use LettuceConnectionFactory to get RedisClient

### DIFF
--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrLettuceStorageAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrLettuceStorageAutoConfiguration.java
@@ -9,16 +9,18 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.context.annotation.Bean;
 
 @AutoConfiguration
-@ConditionalOnBean(RedisClient.class)
+@ConditionalOnBean(LettuceConnectionFactory.class)
 @ConditionalOnProperty(prefix = "org.jobrunr.database", name = "type", havingValue = "redis-lettuce", matchIfMissing = true)
 public class JobRunrLettuceStorageAutoConfiguration {
 
     @Bean(name = "storageProvider", destroyMethod = "close")
     @ConditionalOnMissingBean
-    public StorageProvider jedisStorageProvider(RedisClient redisClient, JobMapper jobMapper, JobRunrProperties properties) {
+    public StorageProvider jedisStorageProvider(LettuceConnectionFactory lettuceConnectionFactory, JobMapper jobMapper, JobRunrProperties properties) {
+        RedisClient redisClient = (RedisClient) lettuceConnectionFactory.getNativeClient();
         LettuceRedisStorageProvider lettuceRedisStorageProvider = new LettuceRedisStorageProvider(redisClient, properties.getDatabase().getTablePrefix());
         lettuceRedisStorageProvider.setJobMapper(jobMapper);
         return lettuceRedisStorageProvider;


### PR DESCRIPTION
Current implementation forces creation of `RedisClient` Bean when user wants to use spring boot autoconfiguration OOTB.

Change derives already created `RedisClient` from `LettuceConnectionFactory` and becomes pure autoconfiguration without any bean declaration