### PR TITLE
Better BackgroundJobServer initialization in Spring

### DIFF
--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
@@ -6,6 +6,7 @@ import jakarta.json.bind.Jsonb;
 import org.jobrunr.dashboard.JobRunrDashboardWebServer;
 import org.jobrunr.dashboard.JobRunrDashboardWebServerConfiguration;
 import org.jobrunr.jobs.details.JobDetailsGenerator;
+import org.jobrunr.jobs.filters.JobFilter;
 import org.jobrunr.jobs.filters.RetryFilter;
 import org.jobrunr.jobs.mappers.JobMapper;
 import org.jobrunr.scheduling.JobRequestScheduler;
@@ -39,6 +40,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.List;
+
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.ofNullable;
@@ -70,14 +73,20 @@ public class JobRunrAutoConfiguration {
         return new JobRequestScheduler(storageProvider, emptyList());
     }
 
-    @Bean(destroyMethod = "stop")
+    @Bean(destroyMethod = "stop", initMethod = "start")
     @ConditionalOnMissingBean
     @ConditionalOnProperty(prefix = "org.jobrunr.background-job-server", name = "enabled", havingValue = "true")
-    public BackgroundJobServer backgroundJobServer(StorageProvider storageProvider, JsonMapper jobRunrJsonMapper, JobActivator jobActivator, BackgroundJobServerConfiguration backgroundJobServerConfiguration, JobRunrProperties properties) {
+    public BackgroundJobServer backgroundJobServer(StorageProvider storageProvider, JsonMapper jobRunrJsonMapper, JobActivator jobActivator, BackgroundJobServerConfiguration backgroundJobServerConfiguration, List<JobFilter> jobFilters) {
         final BackgroundJobServer backgroundJobServer = new BackgroundJobServer(storageProvider, jobRunrJsonMapper, jobActivator, backgroundJobServerConfiguration);
-        backgroundJobServer.setJobFilters(singletonList(new RetryFilter(properties.getJobs().getDefaultNumberOfRetries(), properties.getJobs().getRetryBackOffTimeSeed())));
-        backgroundJobServer.start();
+        backgroundJobServer.setJobFilters(jobFilters);
         return backgroundJobServer;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "org.jobrunr.background-job-server", name = "enabled", havingValue = "true")
+    public RetryFilter defaultRetryFilter(JobRunrProperties properties) {
+        return new RetryFilter(properties.getJobs().getDefaultNumberOfRetries(), properties.getJobs().getRetryBackOffTimeSeed());
     }
 
     @Bean


### PR DESCRIPTION
We are facing two minor problems with default JobRunr Spring Boot starter:

- `BackgroundJobServer` is always started before bean is created. A custom `BeanPostProcessor` is unable to configure server before it starts. Fix: use `initMethod = "start"` which was explicitly designed to allow post processors customize bean before/after it is initialized.
- RetryFilter is added using hard-coded list. We are using custom RetryFilter that is aware of domain specifics. Fix: obtain `JobFilter` list from container, by default there is just default `RetryFilter`.

No tests are needed because there is already `JobRunrAutoConfigurationTest.backgroundJobServerAutoConfigurationTakesIntoAccountDefaultNumberOfRetries` which tests for properly configured retry filter.