### PR TITLE
Add jobSignature to MDC

### DIFF
--- a/core/src/main/java/org/jobrunr/jobs/mappers/MDCMapper.java
+++ b/core/src/main/java/org/jobrunr/jobs/mappers/MDCMapper.java
@@ -11,6 +11,7 @@ public class MDCMapper {
     public static final String JOBRUNR_MDC_KEY = "mdc";
     public static final String JOBRUNR_MDC_JOB_ID_KEY = "jobrunr.jobId";
     public static final String JOBRUNR_MDC_JOB_NAME_KEY = "jobrunr.jobName";
+    public static final String JOBRUNR_MDC_JOB_SIGNATURE_KEY = "jobrunr.jobSignature";
 
     private MDCMapper() {
         // private constructor for SonarQube
@@ -33,6 +34,7 @@ public class MDCMapper {
                 .collect(Collectors.toMap(entry -> entry.getKey().substring(4), entry -> entry.getValue().toString()));
         mdcContextMap.put(JOBRUNR_MDC_JOB_ID_KEY, job.getId().toString());
         mdcContextMap.put(JOBRUNR_MDC_JOB_NAME_KEY, job.getJobName());
+        mdcContextMap.put(JOBRUNR_MDC_JOB_SIGNATURE_KEY, job.getJobSignature());
         MDC.setContextMap(mdcContextMap);
     }
 

--- a/core/src/test/java/org/jobrunr/server/BackgroundJobPerformerTest.java
+++ b/core/src/test/java/org/jobrunr/server/BackgroundJobPerformerTest.java
@@ -348,6 +348,7 @@ class BackgroundJobPerformerTest {
                         Map.of(
                                 "jobrunr.jobId", job.getId().toString(),
                                 "jobrunr.jobName", job.getJobName(),
+                                "jobrunr.jobSignature", job.getJobSignature(),
                                 "testKey", "testValue"
                         ));
 
@@ -378,6 +379,7 @@ class BackgroundJobPerformerTest {
                         Map.of(
                                 "jobrunr.jobId", job.getId().toString(),
                                 "jobrunr.jobName", job.getJobName(),
+                                "jobrunr.jobSignature", job.getJobSignature(),
                                 "testKey", "testValue"
                         ));
         assertThat(MDC.getCopyOfContextMap()).isNullOrEmpty(); // backgroundJobPerformer clears MDC Context


### PR DESCRIPTION
**Context**
Add the job signature to log metadata in order to group logs by job type as job names can be dynamic. This allows for our teams at `Penn Interactive` to group log monitors by the signature and suppress alerts based on a global identifier 

**Changes**

- Adds `jobSignature` to `MDCMapper#loadMDCContextFromJob` which is called in `BackgroundJobPerformer#run`
- Modifies unit tests