### PR TITLE
Escape Postgres table names

### DIFF
--- a/core/src/main/java/org/jobrunr/storage/sql/common/tables/AnsiDatabaseTablePrefixStatementUpdater.java
+++ b/core/src/main/java/org/jobrunr/storage/sql/common/tables/AnsiDatabaseTablePrefixStatementUpdater.java
@@ -56,7 +56,7 @@ public class AnsiDatabaseTablePrefixStatementUpdater implements TablePrefixState
         return updatedStatement;
     }
 
-    private String updateStatementWithTablePrefixForOtherStatements(String statement) {
+    protected String updateStatementWithTablePrefixForOtherStatements(String statement) {
         return statement.replace(DEFAULT_PREFIX, elementPrefixer(tablePrefix, DEFAULT_PREFIX));
     }
 

--- a/core/src/main/java/org/jobrunr/storage/sql/common/tables/PostgresDatabaseTablePrefixStatementUpdater.java
+++ b/core/src/main/java/org/jobrunr/storage/sql/common/tables/PostgresDatabaseTablePrefixStatementUpdater.java
@@ -1,0 +1,43 @@
+package org.jobrunr.storage.sql.common.tables;
+
+import static org.jobrunr.storage.StorageProviderUtils.elementPrefixer;
+
+public class PostgresDatabaseTablePrefixStatementUpdater extends AnsiDatabaseTablePrefixStatementUpdater {
+
+    public PostgresDatabaseTablePrefixStatementUpdater(String tablePrefix) {
+        super(tablePrefix);
+    }
+
+    @Override
+    public String getFQTableName(String tableName) {
+        return String.format("\"%s\"", super.getFQTableName(tableName));
+    }
+
+    private String replacePrefixed(String statement, String targetPrefix, String replacementPrefix) {
+        return statement.replaceAll(
+            "(" +  targetPrefix + ") jobrunr_([a-z_]+)",
+            "$1 \"" + elementPrefixer(replacementPrefix, DEFAULT_PREFIX) + "$2\""
+        );
+    }
+
+    @Override
+    protected String updateStatementWithTablePrefixForIndexStatement(String statement) {
+        String updatedStatement = statement;
+        updatedStatement = replacePrefixed(updatedStatement, "CREATE(?: UNIQUE)? INDEX", indexPrefix);
+        updatedStatement = replacePrefixed(updatedStatement, "DROP INDEX", indexPrefix);
+
+        if (statement.toUpperCase().contains(" ON ")) {
+            updatedStatement = replacePrefixed(updatedStatement, "ON", tablePrefix);
+        }
+
+        return updatedStatement;
+    }
+
+    @Override
+    protected String updateStatementWithTablePrefixForOtherStatements(String statement) {
+        return statement.replaceAll(
+            String.format(" %s([a-z_]+)", DEFAULT_PREFIX),
+            String.format(" \"%s$1\"", elementPrefixer(tablePrefix, DEFAULT_PREFIX))
+        );
+    }
+}

--- a/core/src/main/java/org/jobrunr/storage/sql/postgres/PostgresDialect.java
+++ b/core/src/main/java/org/jobrunr/storage/sql/postgres/PostgresDialect.java
@@ -2,10 +2,16 @@ package org.jobrunr.storage.sql.postgres;
 
 import org.jobrunr.storage.sql.common.db.AnsiDialect;
 
-public class PostgresDialect extends AnsiDialect {
+import static org.jobrunr.storage.sql.common.tables.TablePrefixStatementUpdater.DEFAULT_PREFIX;
 
+public class PostgresDialect extends AnsiDialect {
     @Override
     public String selectForUpdateSkipLocked() {
         return " FOR UPDATE SKIP LOCKED";
+    }
+
+    @Override
+    public String escape(String toEscape) {
+        return toEscape.replaceAll(DEFAULT_PREFIX + "[a-z_]+", "\"$0\"");
     }
 }


### PR DESCRIPTION
## Description
This PR fixes an issue I faced using `jobrunr:` as the tablePrefix.

So far, I only implemented this for PostgreSQL as I do not have an application on hand to test other SQL-based DBs. 

## Postgres
The naming rules in PostgreSQL are as follows:
> SQL identifiers and key words must begin with a letter (a-z, but also letters with diacritical marks and non-Latin letters) or an underscore (_). Subsequent characters in an identifier or key word can be letters, underscores, digits (0-9), or dollar signs ($).

However, using double quotes, it is possible to use essentially any character wanted:
> Quoted identifiers can contain any character, except the character with code zero. (To include a double quote, write two double quotes.) This allows constructing table or column names that would otherwise not be possible, such as ones containing spaces or ampersands. The length limitation still applies.

*https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS*

## MySQL
MySQL would also support using quoted identifiers.
>  Permitted characters in unquoted identifiers:
>    ASCII: [0-9,a-z,A-Z$_] (basic Latin letters, digits 0-9, dollar, underscore)
>    Extended: U+0080 .. U+FFFF 
>
> Permitted characters in quoted identifiers include the full Unicode Basic Multilingual Plane (BMP), except U+0000:
>    ASCII: U+0001 .. U+007F
>    Extended: U+0080 .. U+FFFF 

*https://dev.mysql.com/doc/refman/8.4/en/identifiers.html*

## OracleDB
Same case here.
> Every database object has a name. In a SQL statement, you represent the name of an object with a quoted identifier or a nonquoted identifier.
>    A quoted identifier begins and ends with double quotation marks ("). If you name a schema object using a quoted identifier, then you must use the double quotation marks whenever you refer to that object.
>    A nonquoted identifier is not surrounded by any punctuation.
> You can use either quoted or nonquoted identifiers to name any database object.

*https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Database-Object-Names-and-Qualifiers.html*

## SQL Server, H2, ANSI
I couldn't find any docs mentioning *rules* and *restrictions* (and thus quoting), only conventions.
