### PR TITLE
spring-starter support database.type=mem

### DIFF
--- a/framework-support/jobrunr-spring-boot-2-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrInMemoryStorageAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-2-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrInMemoryStorageAutoConfiguration.java
@@ -1,0 +1,34 @@
+package org.jobrunr.spring.autoconfigure.storage;
+
+import org.jobrunr.jobs.mappers.JobMapper;
+import org.jobrunr.spring.autoconfigure.JobRunrAutoConfiguration;
+import org.jobrunr.spring.autoconfigure.JobRunrProperties;
+import org.jobrunr.storage.StorageProvider;
+import org.jobrunr.storage.InMemoryStorageProvider;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+import static org.jobrunr.utils.StringUtils.isNotNullOrEmpty;
+
+@Configuration
+@AutoConfigureBefore(JobRunrAutoConfiguration.class)
+@ConditionalOnProperty(prefix = "org.jobrunr.database", name = "type", havingValue = "mem", matchIfMissing = false)
+public class JobRunrInMemoryStorageAutoConfiguration {
+
+    @Bean(name = "storageProvider", destroyMethod = "close")
+    @ConditionalOnMissingBean
+    public StorageProvider memStorageProvider(BeanFactory beanFactory, JobMapper jobMapper, JobRunrProperties properties) {
+        StorageProvider storageProvider = new InMemoryStorageProvider();
+        storageProvider.setJobMapper(jobMapper);
+        return storageProvider;
+    }
+
+}

--- a/framework-support/jobrunr-spring-boot-2-starter/src/main/resources/META-INF/spring.factories
+++ b/framework-support/jobrunr-spring-boot-2-starter/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,6 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.jobrunr.spring.autoconfigure.JobRunrAutoConfiguration,\
   org.jobrunr.spring.autoconfigure.storage.JobRunrElasticSearchStorageAutoConfiguration,\
+  org.jobrunr.spring.autoconfigure.storage.JobRunrInMemoryStorageAutoConfiguration,\
   org.jobrunr.spring.autoconfigure.storage.JobRunrJedisStorageAutoConfiguration,\
   org.jobrunr.spring.autoconfigure.storage.JobRunrLettuceRedisClientStorageAutoConfiguration,\
   org.jobrunr.spring.autoconfigure.storage.JobRunrLettuceSpringDataConnectionFactoryStorageAutoConfiguration,\

--- a/framework-support/jobrunr-spring-boot-2-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/framework-support/jobrunr-spring-boot-2-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,5 +1,6 @@
 org.jobrunr.spring.autoconfigure.JobRunrAutoConfiguration
 org.jobrunr.spring.autoconfigure.storage.JobRunrElasticSearchStorageAutoConfiguration
+org.jobrunr.spring.autoconfigure.storage.JobRunrInMemoryStorageAutoConfiguration
 org.jobrunr.spring.autoconfigure.storage.JobRunrJedisStorageAutoConfiguration
 org.jobrunr.spring.autoconfigure.storage.JobRunrLettuceRedisClientStorageAutoConfiguration
 org.jobrunr.spring.autoconfigure.storage.JobRunrLettuceSpringDataConnectionFactoryStorageAutoConfiguration

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/aot/JobRunrBeanFactoryInitializationAotProcessor.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/aot/JobRunrBeanFactoryInitializationAotProcessor.java
@@ -4,6 +4,7 @@ import org.jobrunr.dashboard.ui.model.problems.Problem;
 import org.jobrunr.jobs.annotations.Recurring;
 import org.jobrunr.jobs.lambdas.JobRequestHandler;
 import org.jobrunr.spring.autoconfigure.JobRunrProperties;
+import org.jobrunr.storage.InMemoryStorageProvider;
 import org.jobrunr.storage.StorageProvider;
 import org.jobrunr.storage.nosql.common.migrations.NoSqlMigration;
 import org.jobrunr.storage.nosql.common.migrations.NoSqlMigrationProvider;
@@ -116,6 +117,7 @@ public class JobRunrBeanFactoryInitializationAotProcessor implements BeanFactory
         registerRequiredResources(hints);
 
         registerAllAssignableTypesOf(hints, Problem.class);
+        registerAllAssignableTypesOf(hints, InMemoryStorageProvider.class);
         registerAllAssignableTypesOf(hints, SqlStorageProvider.class);
         registerAllAssignableTypesOf(hints, NoSqlMigration.class);
         registerAllAssignableTypesOf(hints, NoSqlMigrationProvider.class);

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrInMemoryStorageAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrInMemoryStorageAutoConfiguration.java
@@ -1,0 +1,34 @@
+package org.jobrunr.spring.autoconfigure.storage;
+
+import org.jobrunr.jobs.mappers.JobMapper;
+import org.jobrunr.spring.autoconfigure.JobRunrAutoConfiguration;
+import org.jobrunr.spring.autoconfigure.JobRunrProperties;
+import org.jobrunr.storage.StorageProvider;
+import org.jobrunr.storage.InMemoryStorageProvider;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+import static org.jobrunr.utils.StringUtils.isNotNullOrEmpty;
+
+@Configuration
+@AutoConfigureBefore(JobRunrAutoConfiguration.class)
+@ConditionalOnProperty(prefix = "org.jobrunr.database", name = "type", havingValue = "mem", matchIfMissing = false)
+public class JobRunrInMemoryStorageAutoConfiguration {
+
+    @Bean(name = "storageProvider", destroyMethod = "close")
+    @ConditionalOnMissingBean
+    public StorageProvider memStorageProvider(BeanFactory beanFactory, JobMapper jobMapper, JobRunrProperties properties) {
+        StorageProvider storageProvider = new InMemoryStorageProvider();
+        storageProvider.setJobMapper(jobMapper);
+        return storageProvider;
+    }
+
+}

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,5 +1,6 @@
 org.jobrunr.spring.autoconfigure.JobRunrAutoConfiguration
 org.jobrunr.spring.autoconfigure.storage.JobRunrElasticSearchStorageAutoConfiguration
+org.jobrunr.spring.autoconfigure.storage.JobRunrInMemoryStorageAutoConfiguration
 org.jobrunr.spring.autoconfigure.storage.JobRunrJedisStorageAutoConfiguration
 org.jobrunr.spring.autoconfigure.storage.JobRunrLettuceRedisClientStorageAutoConfiguration
 org.jobrunr.spring.autoconfigure.storage.JobRunrMongoDBStorageAutoConfiguration


### PR DESCRIPTION
Recently spring-starter only support sql, mongo, redis.
This PR add supporting mem for org.jobrunr.database.type.