### PR TITLE
Fix `[object Object]` job parameters on job details page

### DIFF
--- a/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/jobs/job-code.js
+++ b/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/jobs/job-code.js
@@ -8,7 +8,12 @@ const JobCode = (props) => {
     const className = job.jobDetails.className.substring(job.jobDetails.className.lastIndexOf(".") + 1);
     const staticFieldName = job.jobDetails.staticFieldName;
     const methodName = job.jobDetails.methodName;
-    const parameters = job.jobDetails.jobParameters.map(jobParameter => jobParameter.object).join(", ")
+    const parameters = job.jobDetails.jobParameters
+        .map(jobParameter => jobParameter.object)
+        .map(object => 
+            typeof object === "object" ? JSON.stringify(object) : object
+        )
+        .join(", ")
 
     let totalFunction = className;
     if (staticFieldName) {


### PR DESCRIPTION
When using serialized complex types as a `JobParameter`, the JobRunr Dashboard would show `[object Object]`.
![old page with the problem](https://github.com/user-attachments/assets/1606101f-7b80-4547-bf49-fc18d6bf8a46)


With this patch, it now displays a readable JSON version.
![new page, now displays JSON](https://github.com/user-attachments/assets/50b2c790-f8e7-4253-b4a2-2867225bfa90)