### PR TITLE
Throw exception when JobRequest is not found

### DIFF
--- a/core/src/main/java/org/jobrunr/jobs/JobDetails.java
+++ b/core/src/main/java/org/jobrunr/jobs/JobDetails.java
@@ -9,6 +9,7 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 import static org.jobrunr.utils.CollectionUtils.asArrayList;
+import static org.jobrunr.utils.JobUtils.assertJobExists;
 
 public class JobDetails {
 
@@ -25,6 +26,7 @@ public class JobDetails {
 
     public JobDetails(JobRequest jobRequest) {
         this(jobRequest.getJobRequestHandler().getName(), null, "run", asList(new JobParameter(jobRequest)));
+        assertJobExists(this);
         this.cacheable = true;
     }
 

--- a/core/src/main/java/org/jobrunr/scheduling/JobBuilder.java
+++ b/core/src/main/java/org/jobrunr/scheduling/JobBuilder.java
@@ -18,7 +18,6 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.jobrunr.utils.CollectionUtils.asSet;
-import static org.jobrunr.utils.JobUtils.assertJobExists;
 
 /**
  * This class is used to build a {@link Job} using a job lambda or a {@link JobRequest}.
@@ -208,7 +207,6 @@ public class JobBuilder {
             throw new IllegalArgumentException("JobRequest must be present.");
         }
         JobDetails jobDetails = new JobDetails(jobRequest);
-        assertJobExists(jobDetails);
         return build(jobDetails);
     }
 

--- a/core/src/test/java/org/jobrunr/jobs/JobDetailsTest.java
+++ b/core/src/test/java/org/jobrunr/jobs/JobDetailsTest.java
@@ -1,11 +1,14 @@
 package org.jobrunr.jobs;
 
+import org.jobrunr.scheduling.exceptions.JobMethodNotFoundException;
+import org.jobrunr.stubs.TestInvalidJobRequest;
 import org.jobrunr.stubs.TestJobRequest;
 import org.jobrunr.stubs.TestJobRequest.TestJobRequestHandler;
 import org.jobrunr.stubs.TestService;
 import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.jobrunr.JobRunrAssertions.assertThat;
 import static org.jobrunr.jobs.JobDetailsTestBuilder.jobDetails;
 
@@ -66,5 +69,12 @@ class JobDetailsTest {
                 .hasMethodName("run")
                 .hasArgs(jobRequest)
                 .isCacheable();
+    }
+
+    @Test
+    void testJobDetailsFromInvalidJobRequest() {
+        final TestInvalidJobRequest jobRequest = new TestInvalidJobRequest();
+        assertThatThrownBy(() -> new JobDetails(jobRequest))
+                .isInstanceOf(JobMethodNotFoundException.class);
     }
 }


### PR DESCRIPTION
Throw exception when JobRequest is not found resulting in better dev experience.

This fixes https://github.com/jobrunr/jobrunr-pro/issues/517.