### PR TITLE
Improve Progress bar

### DIFF
--- a/core/src/main/java/org/jobrunr/jobs/context/JobDashboardProgressBar.java
+++ b/core/src/main/java/org/jobrunr/jobs/context/JobDashboardProgressBar.java
@@ -38,8 +38,15 @@ public class JobDashboardProgressBar {
     /**
      * Allows to increase the progress bar in the dashboard for a normal job using the {@link JobContext}
      */
-    public void increaseByOne() {
-        jobDashboardProgress.increaseByOne();
+    public void incrementSucceeded() {
+        jobDashboardProgress.incrementSucceeded();
+    }
+
+    /**
+     * Allows to increase the failed count of the progress bar in the dashboard for a normal job using the {@link JobContext}
+     */
+    public void incrementFailed() {
+        jobDashboardProgress.incrementFailed();
     }
 
     public int getProgress() {
@@ -60,6 +67,7 @@ public class JobDashboardProgressBar {
 
     /**
      * Sets the progress for the ProgressBar on the dashboard and returns if it has changes.
+     *
      * @param succeededAmount the amount of succeeded items
      * @return true if the progress has changed, false otherwise
      */
@@ -102,8 +110,12 @@ public class JobDashboardProgressBar {
             }
         }
 
-        public void increaseByOne() {
+        public void incrementSucceeded() {
             setProgress(succeededAmount + 1);
+        }
+
+        public void incrementFailed() {
+            setProgress(failedAmount + 1);
         }
 
         public boolean setProgress(Long succeededAmount) {


### PR DESCRIPTION
Allow to increment the progressbar both for succeeded and failed. Fixes #1215.

> this is a breaking change as it is renamed from `increaseByOne()` to `incrementSucceeded()`