### PR TITLE
cleanup creation of datasources in storage provider tests

### DIFF
--- a/core/src/test/java/org/jobrunr/storage/sql/SqlStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/SqlStorageProviderTest.java
@@ -69,7 +69,7 @@ public abstract class SqlStorageProviderTest extends StorageProviderTest {
         System.out.println("=========================================================");
     }
 
-    protected abstract DataSource getDataSource();
+    public abstract DataSource getDataSource();
 
     protected void cleanupDatabase(DataSource dataSource) {
         if (getTestMethodIndex() < 3) {

--- a/core/src/test/java/org/jobrunr/storage/sql/db2/AbstractDB2StorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/db2/AbstractDB2StorageProviderTest.java
@@ -1,16 +1,20 @@
 package org.jobrunr.storage.sql.db2;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.jobrunr.storage.sql.SqlStorageProviderTest;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.extension.AfterAllSubclasses;
 import org.junit.jupiter.extension.BeforeAllSubclasses;
 import org.junit.jupiter.extension.ForAllSubclassesExtension;
 import org.testcontainers.containers.Db2Container;
 
+import javax.sql.DataSource;
 import java.time.Duration;
 import java.time.Instant;
 
 import static java.time.Instant.now;
+import static org.jobrunr.storage.sql.SqlTestUtils.toHikariDataSource;
 
 @ExtendWith(ForAllSubclassesExtension.class)
 public abstract class AbstractDB2StorageProviderTest extends SqlStorageProviderTest {
@@ -18,6 +22,22 @@ public abstract class AbstractDB2StorageProviderTest extends SqlStorageProviderT
     protected static final Db2Container sqlContainer = new Db2Container("icr.io/db2_community/db2:12.1.0.0")
             .withPrivilegedMode(true)
             .acceptLicense();
+
+    protected static HikariDataSource dataSource;
+
+    @Override
+    public DataSource getDataSource() {
+        if (dataSource == null) {
+            dataSource = toHikariDataSource(sqlContainer);
+        }
+        return dataSource;
+    }
+
+    @AfterAll
+    public static void destroyDatasource() {
+        dataSource.close();
+        dataSource = null;
+    }
 
     @BeforeAllSubclasses
     public static void startSqlContainer() {

--- a/core/src/test/java/org/jobrunr/storage/sql/db2/DB2StorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/db2/DB2StorageProviderTest.java
@@ -9,19 +9,4 @@ import static org.jobrunr.storage.sql.SqlTestUtils.toHikariDataSource;
 
 class DB2StorageProviderTest extends AbstractDB2StorageProviderTest {
 
-    private static HikariDataSource dataSource;
-
-    @Override
-    protected DataSource getDataSource() {
-        if (dataSource == null) {
-            dataSource = toHikariDataSource(sqlContainer);
-        }
-        return dataSource;
-    }
-
-    @AfterAll
-    public static void destroyDatasource() {
-        dataSource.close();
-        dataSource = null;
-    }
 }

--- a/core/src/test/java/org/jobrunr/storage/sql/db2/DB2TablePrefixStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/db2/DB2TablePrefixStorageProviderTest.java
@@ -24,22 +24,6 @@ import static org.jobrunr.utils.resilience.RateLimiter.Builder.rateLimit;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class DB2TablePrefixStorageProviderTest extends AbstractDB2StorageProviderTest {
 
-    private static HikariDataSource dataSource;
-
-    @Override
-    protected DataSource getDataSource() {
-        if (dataSource == null) {
-            dataSource = toHikariDataSource(sqlContainer);
-        }
-        return dataSource;
-    }
-
-    @AfterAll
-    public static void destroyDatasource() {
-        dataSource.close();
-        dataSource = null;
-    }
-
     @BeforeAll
     void runInitScript() {
         doInTransaction(getDataSource(),

--- a/core/src/test/java/org/jobrunr/storage/sql/h2/AgroalH2StorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/h2/AgroalH2StorageProviderTest.java
@@ -15,7 +15,7 @@ class AgroalH2StorageProviderTest extends SqlStorageProviderTest {
     private static AgroalDataSource dataSource;
 
     @Override
-    protected DataSource getDataSource() {
+    public DataSource getDataSource() {
         try {
             if (dataSource == null) {
                 AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()

--- a/core/src/test/java/org/jobrunr/storage/sql/h2/CommonsDbcpAutoCommitFalseH2StorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/h2/CommonsDbcpAutoCommitFalseH2StorageProviderTest.java
@@ -5,7 +5,7 @@ import org.apache.commons.dbcp2.BasicDataSource;
 public class CommonsDbcpAutoCommitFalseH2StorageProviderTest extends CommonsDbcpH2StorageProviderTest {
 
     @Override
-    protected BasicDataSource getDataSource() {
+    public BasicDataSource getDataSource() {
         return getDataSource(false);
     }
 }

--- a/core/src/test/java/org/jobrunr/storage/sql/h2/CommonsDbcpH2StorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/h2/CommonsDbcpH2StorageProviderTest.java
@@ -11,7 +11,7 @@ public class CommonsDbcpH2StorageProviderTest extends SqlStorageProviderTest {
     private static BasicDataSource dataSource;
 
     @Override
-    protected BasicDataSource getDataSource() {
+    public BasicDataSource getDataSource() {
         return getDataSource(true);
     }
 

--- a/core/src/test/java/org/jobrunr/storage/sql/h2/HikariH2AutoCommitFalseStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/h2/HikariH2AutoCommitFalseStorageProviderTest.java
@@ -5,7 +5,7 @@ import com.zaxxer.hikari.HikariDataSource;
 public class HikariH2AutoCommitFalseStorageProviderTest extends HikariH2StorageProviderTest {
 
     @Override
-    protected HikariDataSource getDataSource() {
+    public HikariDataSource getDataSource() {
         return getDataSource(false);
     }
 }

--- a/core/src/test/java/org/jobrunr/storage/sql/h2/HikariH2StorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/h2/HikariH2StorageProviderTest.java
@@ -13,7 +13,7 @@ public class HikariH2StorageProviderTest extends SqlStorageProviderTest {
     private static HikariDataSource dataSource;
 
     @Override
-    protected HikariDataSource getDataSource() {
+    public HikariDataSource getDataSource() {
         return getDataSource(true);
     }
 

--- a/core/src/test/java/org/jobrunr/storage/sql/h2/NativePoolH2TablePrefixStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/h2/NativePoolH2TablePrefixStorageProviderTest.java
@@ -36,7 +36,7 @@ public class NativePoolH2TablePrefixStorageProviderTest extends SqlStorageProvid
     }
 
     @Override
-    protected DataSource getDataSource() {
+    public DataSource getDataSource() {
         if (dataSource == null) {
             dataSource = JdbcConnectionPool.create("jdbc:h2:mem:test-native-pool;INIT=CREATE SCHEMA IF NOT EXISTS SOME_SCHEMA;DB_CLOSE_DELAY=-1;", "sa", "sa");
         }

--- a/core/src/test/java/org/jobrunr/storage/sql/h2/TomcatJdbcPoolAutoCommitFalseH2StorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/h2/TomcatJdbcPoolAutoCommitFalseH2StorageProviderTest.java
@@ -5,7 +5,7 @@ import org.apache.tomcat.jdbc.pool.DataSource;
 public class TomcatJdbcPoolAutoCommitFalseH2StorageProviderTest extends TomcatJdbcPoolH2StorageProviderTest {
 
     @Override
-    protected DataSource getDataSource() {
+    public DataSource getDataSource() {
         return getDataSource(false);
     }
 }

--- a/core/src/test/java/org/jobrunr/storage/sql/h2/TomcatJdbcPoolH2StorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/h2/TomcatJdbcPoolH2StorageProviderTest.java
@@ -12,7 +12,7 @@ public class TomcatJdbcPoolH2StorageProviderTest extends SqlStorageProviderTest 
     private static DataSource dataSource;
 
     @Override
-    protected DataSource getDataSource() {
+    public DataSource getDataSource() {
         return getDataSource(true);
     }
 

--- a/core/src/test/java/org/jobrunr/storage/sql/mariadb/AbstractMariaDbStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/mariadb/AbstractMariaDbStorageProviderTest.java
@@ -1,21 +1,41 @@
 package org.jobrunr.storage.sql.mariadb;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.jobrunr.storage.sql.SqlStorageProviderTest;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.extension.AfterAllSubclasses;
 import org.junit.jupiter.extension.BeforeAllSubclasses;
 import org.junit.jupiter.extension.ForAllSubclassesExtension;
 import org.testcontainers.containers.MariaDBContainer;
 
+import javax.sql.DataSource;
 import java.time.Duration;
 import java.time.Instant;
 
 import static java.time.Instant.now;
+import static org.jobrunr.storage.sql.SqlTestUtils.toHikariDataSource;
 
 @ExtendWith(ForAllSubclassesExtension.class)
 public abstract class AbstractMariaDbStorageProviderTest extends SqlStorageProviderTest {
 
     protected static MariaDBContainer sqlContainer = new MariaDBContainer<>("mariadb").withEnv("TZ", "UTC");
+
+    protected static HikariDataSource dataSource;
+
+    @Override
+    public DataSource getDataSource() {
+        if (dataSource == null) {
+            dataSource = toHikariDataSource(sqlContainer, "?rewriteBatchedStatements=true&useBulkStmts=false");
+        }
+        return dataSource;
+    }
+
+    @AfterAll
+    public static void destroyDatasource() {
+        dataSource.close();
+        dataSource = null;
+    }
 
     @BeforeAllSubclasses
     public static void startSqlContainer() {

--- a/core/src/test/java/org/jobrunr/storage/sql/mariadb/MariaDbStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/mariadb/MariaDbStorageProviderTest.java
@@ -9,19 +9,4 @@ import static org.jobrunr.storage.sql.SqlTestUtils.toHikariDataSource;
 
 class MariaDbStorageProviderTest extends AbstractMariaDbStorageProviderTest {
 
-    private static HikariDataSource dataSource;
-
-    @Override
-    protected DataSource getDataSource() {
-        if (dataSource == null) {
-            dataSource = toHikariDataSource(sqlContainer, "?rewriteBatchedStatements=true&useBulkStmts=false");
-        }
-        return dataSource;
-    }
-
-    @AfterAll
-    public static void destroyDatasource() {
-        dataSource.close();
-        dataSource = null;
-    }
 }

--- a/core/src/test/java/org/jobrunr/storage/sql/mariadb/MariaDbTablePrefixStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/mariadb/MariaDbTablePrefixStorageProviderTest.java
@@ -19,23 +19,6 @@ import static org.jobrunr.utils.resilience.RateLimiter.Builder.rateLimit;
 
 class MariaDbTablePrefixStorageProviderTest extends AbstractMariaDbStorageProviderTest {
 
-    private static MariaDbPoolDataSource dataSource;
-
-    @Override
-    protected DataSource getDataSource() {
-        if (dataSource == null) {
-            try {
-                dataSource = new MariaDbPoolDataSource();
-                dataSource.setUrl(sqlContainer.getJdbcUrl() + "?rewriteBatchedStatements=true&pool=true&useBulkStmts=false");
-                dataSource.setUser(sqlContainer.getUsername());
-                dataSource.setPassword(sqlContainer.getPassword());
-            } catch (SQLException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        return dataSource;
-    }
-
     @Override
     protected StorageProvider getStorageProvider() {
         final StorageProvider storageProvider = SqlStorageProviderFactory.using(getDataSource(), "SOME_PREFIX_");
@@ -58,11 +41,5 @@ class MariaDbTablePrefixStorageProviderTest extends AbstractMariaDbStorageProvid
                 .hasTable("SOME_PREFIX_JOBRUNR_METADATA")
                 .hasView("SOME_PREFIX_JOBRUNR_JOBS_STATS")
                 .hasIndexesMatching(8, new Condition<>(name -> name.startsWith("SOME_PREFIX_JOBRUNR_"), "Index matches"));
-    }
-
-    @AfterAll
-    public static void destroyDatasource() {
-        dataSource.close();
-        dataSource = null;
     }
 }

--- a/core/src/test/java/org/jobrunr/storage/sql/mysql/AbstractMySQLStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/mysql/AbstractMySQLStorageProviderTest.java
@@ -1,21 +1,41 @@
 package org.jobrunr.storage.sql.mysql;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.jobrunr.storage.sql.SqlStorageProviderTest;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.extension.AfterAllSubclasses;
 import org.junit.jupiter.extension.BeforeAllSubclasses;
 import org.junit.jupiter.extension.ForAllSubclassesExtension;
 import org.testcontainers.containers.MySQLContainer;
 
+import javax.sql.DataSource;
 import java.time.Duration;
 import java.time.Instant;
 
 import static java.time.Instant.now;
+import static org.jobrunr.storage.sql.SqlTestUtils.toHikariDataSource;
 
 @ExtendWith(ForAllSubclassesExtension.class)
 public abstract class AbstractMySQLStorageProviderTest extends SqlStorageProviderTest {
 
     protected static MySQLContainer sqlContainer = new MySQLContainer<>("mysql:8.0.32").withEnv("TZ", "UTC");
+
+    protected static HikariDataSource dataSource;
+
+    @Override
+    public DataSource getDataSource() {
+        if (dataSource == null) {
+            dataSource = toHikariDataSource(sqlContainer, "?rewriteBatchedStatements=true&useSSL=false");
+        }
+        return dataSource;
+    }
+
+    @AfterAll
+    public static void destroyDatasource() {
+        dataSource.close();
+        dataSource = null;
+    }
 
     @BeforeAllSubclasses
     public static void startSqlContainer() {

--- a/core/src/test/java/org/jobrunr/storage/sql/mysql/MySQLStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/mysql/MySQLStorageProviderTest.java
@@ -9,19 +9,4 @@ import static org.jobrunr.storage.sql.SqlTestUtils.toHikariDataSource;
 
 class MySQLStorageProviderTest extends AbstractMySQLStorageProviderTest {
 
-    private static HikariDataSource dataSource;
-
-    @Override
-    protected DataSource getDataSource() {
-        if (dataSource == null) {
-            dataSource = toHikariDataSource(sqlContainer, "?rewriteBatchedStatements=true&useSSL=false");
-        }
-        return dataSource;
-    }
-
-    @AfterAll
-    public static void destroyDatasource() {
-        dataSource.close();
-        dataSource = null;
-    }
 }

--- a/core/src/test/java/org/jobrunr/storage/sql/mysql/MySQLTablePrefixStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/mysql/MySQLTablePrefixStorageProviderTest.java
@@ -19,24 +19,6 @@ import static org.jobrunr.utils.resilience.RateLimiter.Builder.rateLimit;
 
 class MySQLTablePrefixStorageProviderTest extends AbstractMySQLStorageProviderTest {
 
-    private static MysqlDataSource dataSource;
-
-    @Override
-    protected DataSource getDataSource() {
-        if (dataSource == null) {
-            dataSource = new MysqlConnectionPoolDataSource();
-            dataSource.setUrl(sqlContainer.getJdbcUrl() + "?rewriteBatchedStatements=true&pool=true&useSSL=false");
-            dataSource.setUser(sqlContainer.getUsername());
-            dataSource.setPassword(sqlContainer.getPassword());
-        }
-        return dataSource;
-    }
-
-    @AfterAll
-    public static void destroyDatasource() {
-        dataSource = null;
-    }
-
     @Override
     protected StorageProvider getStorageProvider() {
         final StorageProvider storageProvider = SqlStorageProviderFactory.using(getDataSource(), "SOME_PREFIX_");

--- a/core/src/test/java/org/jobrunr/storage/sql/oracle/AbstractOracleStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/oracle/AbstractOracleStorageProviderTest.java
@@ -1,7 +1,9 @@
 package org.jobrunr.storage.sql.oracle;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.jobrunr.storage.sql.DatabaseCleaner;
 import org.jobrunr.storage.sql.SqlStorageProviderTest;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.extension.AfterAllSubclasses;
 import org.junit.jupiter.extension.BeforeAllSubclasses;
@@ -13,6 +15,7 @@ import java.time.Duration;
 import java.time.Instant;
 
 import static java.time.Instant.now;
+import static org.jobrunr.storage.sql.SqlTestUtils.toHikariDataSource;
 
 @ExtendWith(ForAllSubclassesExtension.class)
 public abstract class AbstractOracleStorageProviderTest extends SqlStorageProviderTest {
@@ -29,6 +32,29 @@ public abstract class AbstractOracleStorageProviderTest extends SqlStorageProvid
         Instant before = now();
         sqlContainer.start();
         printSqlContainerDetails(sqlContainer, Duration.between(before, now()));
+    }
+
+    protected static HikariDataSource dataSource;
+
+    @Override
+    public DataSource getDataSource() {
+        if (dataSource == null) {
+            // dataSource = toHikariDataSource("jdbc:oracle:thin:@localhost:1527:xe".replace(":xe", ":ORCL"), "system", "oracle");
+
+            System.out.println("==========================================================================================");
+            System.out.println(sqlContainer.getLogs());
+            System.out.println("==========================================================================================");
+
+            dataSource = toHikariDataSource(sqlContainer.getJdbcUrl().replace(":xe", ":ORCL"), sqlContainer.getUsername(), sqlContainer.getPassword());
+        }
+
+        return dataSource;
+    }
+
+    @AfterAll
+    public static void destroyDatasource() {
+        dataSource.close();
+        dataSource = null;
     }
 
     @AfterAllSubclasses

--- a/core/src/test/java/org/jobrunr/storage/sql/oracle/OracleStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/oracle/OracleStorageProviderTest.java
@@ -13,28 +13,4 @@ import static org.jobrunr.storage.sql.SqlTestUtils.toHikariDataSource;
 @RunTestIfDockerImageExists("container-registry.oracle.com/database/standard:12.1.0.2")
 class OracleStorageProviderTest extends AbstractOracleStorageProviderTest {
 
-    //    docker run -d --env DB_PASSWD=oracle -p 1527:1521 -p 5507:5500 -it --shm-size="8g" container-registry.oracle.com/database/standard:12.1.0.2
-
-    private static HikariDataSource dataSource;
-
-    @Override
-    protected DataSource getDataSource() {
-        if (dataSource == null) {
-            // dataSource = toHikariDataSource("jdbc:oracle:thin:@localhost:1527:xe".replace(":xe", ":ORCL"), "system", "oracle");
-
-            System.out.println("==========================================================================================");
-            System.out.println(sqlContainer.getLogs());
-            System.out.println("==========================================================================================");
-
-            dataSource = toHikariDataSource(sqlContainer.getJdbcUrl().replace(":xe", ":ORCL"), sqlContainer.getUsername(), sqlContainer.getPassword());
-        }
-
-        return dataSource;
-    }
-
-    @AfterAll
-    public static void destroyDatasource() {
-        dataSource.close();
-        dataSource = null;
-    }
 }

--- a/core/src/test/java/org/jobrunr/storage/sql/oracle/OracleTablePrefixStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/oracle/OracleTablePrefixStorageProviderTest.java
@@ -28,29 +28,6 @@ import static org.jobrunr.utils.resilience.RateLimiter.Builder.rateLimit;
 @RunTestIfDockerImageExists("container-registry.oracle.com/database/standard:12.1.0.2")
 public class OracleTablePrefixStorageProviderTest extends AbstractOracleStorageProviderTest {
 
-    private static HikariDataSource dataSource;
-
-    @Override
-    protected DataSource getDataSource() {
-        if (dataSource == null) {
-            // dataSource = toHikariDataSource("jdbc:oracle:thin:@localhost:1527:xe".replace(":xe", ":ORCL"), "system", "oracle");
-
-            System.out.println("==========================================================================================");
-            System.out.println(sqlContainer.getLogs());
-            System.out.println("==========================================================================================");
-
-            dataSource = toHikariDataSource(sqlContainer.getJdbcUrl().replace(":xe", ":ORCL"), sqlContainer.getUsername(), sqlContainer.getPassword());
-        }
-
-        return dataSource;
-    }
-
-    @AfterAll
-    public static void destroyDatasource() {
-        dataSource.close();
-        dataSource = null;
-    }
-
     @BeforeAll
     void runInitScript() {
         doInTransaction(getDataSource(), statement -> {

--- a/core/src/test/java/org/jobrunr/storage/sql/postgres/AbstractPostgresStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/postgres/AbstractPostgresStorageProviderTest.java
@@ -1,21 +1,41 @@
 package org.jobrunr.storage.sql.postgres;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.jobrunr.storage.sql.SqlStorageProviderTest;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.extension.AfterAllSubclasses;
 import org.junit.jupiter.extension.BeforeAllSubclasses;
 import org.junit.jupiter.extension.ForAllSubclassesExtension;
 import org.testcontainers.containers.PostgreSQLContainer;
 
+import javax.sql.DataSource;
 import java.time.Duration;
 import java.time.Instant;
 
 import static java.time.Instant.now;
+import static org.jobrunr.storage.sql.SqlTestUtils.toHikariDataSource;
 
 @ExtendWith(ForAllSubclassesExtension.class)
 public abstract class AbstractPostgresStorageProviderTest extends SqlStorageProviderTest {
 
     protected static PostgreSQLContainer sqlContainer = new PostgreSQLContainer<>("postgres:12");
+
+    protected static HikariDataSource dataSource;
+
+    @Override
+    public DataSource getDataSource() {
+        if (dataSource == null) {
+            dataSource = toHikariDataSource(sqlContainer);
+        }
+        return dataSource;
+    }
+
+    @AfterAll
+    public static void destroyDatasource() {
+        dataSource.close();
+        dataSource = null;
+    }
 
     @BeforeAllSubclasses
     public static void startSqlContainer() {

--- a/core/src/test/java/org/jobrunr/storage/sql/postgres/CloudSqlPostgresStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/postgres/CloudSqlPostgresStorageProviderTest.java
@@ -21,7 +21,7 @@ class CloudSqlPostgresStorageProviderTest extends SqlStorageProviderTest {
     private static HikariDataSource dataSource;
 
     @Override
-    protected DataSource getDataSource() {
+    public DataSource getDataSource() {
         if (dataSource == null) {
             HikariConfig config = new HikariConfig();
             config.setJdbcUrl(String.format("jdbc:postgresql:///%s", System.getenv("DB_NAME")));

--- a/core/src/test/java/org/jobrunr/storage/sql/postgres/PostgresStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/postgres/PostgresStorageProviderTest.java
@@ -9,19 +9,4 @@ import static org.jobrunr.storage.sql.SqlTestUtils.toHikariDataSource;
 
 class PostgresStorageProviderTest extends AbstractPostgresStorageProviderTest {
 
-    private static HikariDataSource dataSource;
-
-    @Override
-    protected DataSource getDataSource() {
-        if (dataSource == null) {
-            dataSource = toHikariDataSource(sqlContainer);
-        }
-        return dataSource;
-    }
-
-    @AfterAll
-    public static void destroyDatasource() {
-        dataSource.close();
-        dataSource = null;
-    }
 }

--- a/core/src/test/java/org/jobrunr/storage/sql/postgres/PostgresTablePrefixStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/postgres/PostgresTablePrefixStorageProviderTest.java
@@ -24,22 +24,6 @@ import static org.jobrunr.utils.resilience.RateLimiter.Builder.rateLimit;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class PostgresTablePrefixStorageProviderTest extends AbstractPostgresStorageProviderTest {
 
-    private static HikariDataSource dataSource;
-
-    @Override
-    protected DataSource getDataSource() {
-        if (dataSource == null) {
-            dataSource = toHikariDataSource(sqlContainer);
-        }
-        return dataSource;
-    }
-
-    @AfterAll
-    public static void destroyDatasource() {
-        dataSource.close();
-        dataSource = null;
-    }
-
     @BeforeAll
     void runInitScript() {
         doInTransaction(getDataSource(),

--- a/core/src/test/java/org/jobrunr/storage/sql/sqlite/SqLiteStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/sqlite/SqLiteStorageProviderTest.java
@@ -13,7 +13,7 @@ class SqLiteStorageProviderTest extends SqlStorageProviderTest {
     private static SQLiteDataSource dataSource;
 
     @Override
-    protected DataSource getDataSource() {
+    public DataSource getDataSource() {
         if (dataSource == null) {
             deleteFile("/tmp/jobrunr-test.db");
 

--- a/core/src/test/java/org/jobrunr/storage/sql/sqlserver/AbstractSQLServerStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/sqlserver/AbstractSQLServerStorageProviderTest.java
@@ -1,6 +1,8 @@
 package org.jobrunr.storage.sql.sqlserver;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.jobrunr.storage.sql.SqlStorageProviderTest;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.extension.AfterAllSubclasses;
 import org.junit.jupiter.extension.BeforeAllSubclasses;
@@ -8,15 +10,33 @@ import org.junit.jupiter.extension.ForAllSubclassesExtension;
 import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import javax.sql.DataSource;
 import java.time.Duration;
 import java.time.Instant;
 
 import static java.time.Instant.now;
+import static org.jobrunr.storage.sql.SqlTestUtils.toHikariDataSource;
 
 @ExtendWith(ForAllSubclassesExtension.class)
 public abstract class AbstractSQLServerStorageProviderTest extends SqlStorageProviderTest {
 
     protected static MSSQLServerContainer sqlContainer = new MSSQLServerContainer<>(DockerImageName.parse("mcr.microsoft.com/azure-sql-edge").asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server"));
+
+    protected static HikariDataSource dataSource;
+
+    @Override
+    public DataSource getDataSource() {
+        if (dataSource == null) {
+            dataSource = toHikariDataSource(sqlContainer);
+        }
+        return dataSource;
+    }
+
+    @AfterAll
+    public static void destroyDatasource() {
+        dataSource.close();
+        dataSource = null;
+    }
 
     @BeforeAllSubclasses
     public static void startSqlContainer() {

--- a/core/src/test/java/org/jobrunr/storage/sql/sqlserver/SQLServerStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/sqlserver/SQLServerStorageProviderTest.java
@@ -9,19 +9,4 @@ import static org.jobrunr.storage.sql.SqlTestUtils.toHikariDataSource;
 
 class SQLServerStorageProviderTest extends AbstractSQLServerStorageProviderTest {
 
-    private static HikariDataSource dataSource;
-
-    @Override
-    protected DataSource getDataSource() {
-        if (dataSource == null) {
-            dataSource = toHikariDataSource(sqlContainer);
-        }
-        return dataSource;
-    }
-
-    @AfterAll
-    public static void destroyDatasource() {
-        dataSource.close();
-        dataSource = null;
-    }
 }

--- a/core/src/test/java/org/jobrunr/storage/sql/sqlserver/SQLServerTablePrefixStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/sqlserver/SQLServerTablePrefixStorageProviderTest.java
@@ -24,22 +24,6 @@ import static org.jobrunr.utils.resilience.RateLimiter.Builder.rateLimit;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SQLServerTablePrefixStorageProviderTest extends AbstractSQLServerStorageProviderTest {
 
-    private static HikariDataSource dataSource;
-
-    @Override
-    protected DataSource getDataSource() {
-        if (dataSource == null) {
-            dataSource = toHikariDataSource(sqlContainer);
-        }
-        return dataSource;
-    }
-
-    @AfterAll
-    public static void destroyDatasource() {
-        dataSource.close();
-        dataSource = null;
-    }
-
     @BeforeAll
     void runInitScript() {
         doInTransaction(getDataSource(),


### PR DESCRIPTION
- cleanup duplication of datasources
- make `getDataSource` public to better comply additional tests in Pro