### PR TITLE
Drop `org` prefix from JobRunr's Spring properties

### DIFF
--- a/framework-support/jobrunr-spring-boot-2-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-2-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
@@ -66,7 +66,7 @@ public class JobRunrAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "org.jobrunr.job-scheduler", name = "enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(prefix = "jobrunr.job-scheduler", name = "enabled", havingValue = "true", matchIfMissing = true)
     public JobScheduler jobScheduler(StorageProvider storageProvider, JobRunrProperties properties) {
         final JobDetailsGenerator jobDetailsGenerator = newInstance(properties.getJobScheduler().getJobDetailsGenerator());
         return new JobScheduler(storageProvider, jobDetailsGenerator, emptyList());
@@ -74,14 +74,14 @@ public class JobRunrAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "org.jobrunr.job-scheduler", name = "enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(prefix = "jobrunr.job-scheduler", name = "enabled", havingValue = "true", matchIfMissing = true)
     public JobRequestScheduler jobRequestScheduler(StorageProvider storageProvider) {
         return new JobRequestScheduler(storageProvider, emptyList());
     }
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "org.jobrunr.background-job-server", name = "enabled", havingValue = "true")
+    @ConditionalOnProperty(prefix = "jobrunr.background-job-server", name = "enabled", havingValue = "true")
     public BackgroundJobServer backgroundJobServer(StorageProvider storageProvider, JsonMapper jobRunrJsonMapper, JobActivator jobActivator, BackgroundJobServerConfiguration backgroundJobServerConfiguration, JobRunrProperties properties) {
         final BackgroundJobServer backgroundJobServer = new BackgroundJobServer(storageProvider, jobRunrJsonMapper, jobActivator, backgroundJobServerConfiguration);
         backgroundJobServer.setJobFilters(singletonList(new RetryFilter(properties.getJobs().getDefaultNumberOfRetries(), properties.getJobs().getRetryBackOffTimeSeed())));
@@ -90,7 +90,7 @@ public class JobRunrAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "org.jobrunr.background-job-server", name = "enabled", havingValue = "true")
+    @ConditionalOnProperty(prefix = "jobrunr.background-job-server", name = "enabled", havingValue = "true")
     public BackgroundJobServerWorkerPolicy backgroundJobServerWorkerPolicy(JobRunrProperties properties) {
         JobRunrProperties.BackgroundJobServer backgroundJobServerProperties = properties.getBackgroundJobServer();
         BackgroundJobServerThreadType threadType = ofNullable(backgroundJobServerProperties.getThreadType()).orElse(BackgroundJobServerThreadType.getDefaultThreadType());
@@ -100,7 +100,7 @@ public class JobRunrAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "org.jobrunr.background-job-server", name = "enabled", havingValue = "true")
+    @ConditionalOnProperty(prefix = "jobrunr.background-job-server", name = "enabled", havingValue = "true")
     public BackgroundJobServerConfiguration backgroundJobServerConfiguration(JobRunrProperties properties, BackgroundJobServerWorkerPolicy backgroundJobServerWorkerPolicy) {
         PropertyMapper map = PropertyMapper.get();
         BackgroundJobServerConfiguration backgroundJobServerConfiguration = usingStandardBackgroundJobServerConfiguration();
@@ -123,14 +123,14 @@ public class JobRunrAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "org.jobrunr.dashboard", name = "enabled", havingValue = "true")
+    @ConditionalOnProperty(prefix = "jobrunr.dashboard", name = "enabled", havingValue = "true")
     public JobRunrDashboardWebServer dashboardWebServer(StorageProvider storageProvider, JsonMapper jobRunrJsonMapper, JobRunrDashboardWebServerConfiguration dashboardWebServerConfiguration) {
         return new JobRunrDashboardWebServer(storageProvider, jobRunrJsonMapper, dashboardWebServerConfiguration);
     }
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "org.jobrunr.dashboard", name = "enabled", havingValue = "true")
+    @ConditionalOnProperty(prefix = "jobrunr.dashboard", name = "enabled", havingValue = "true")
     public JobRunrDashboardWebServerConfiguration dashboardWebServerConfiguration(JobRunrProperties properties) {
         return usingStandardDashboardConfiguration()
                 .andPort(properties.getDashboard().getPort())

--- a/framework-support/jobrunr-spring-boot-2-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrProperties.java
+++ b/framework-support/jobrunr-spring-boot-2-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrProperties.java
@@ -9,7 +9,7 @@ import org.springframework.boot.convert.DurationUnit;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 
-@ConfigurationProperties(prefix = "org.jobrunr")
+@ConfigurationProperties(prefix = "jobrunr")
 public class JobRunrProperties {
 
     private Database database = new Database();

--- a/framework-support/jobrunr-spring-boot-2-starter/src/main/java/org/jobrunr/spring/autoconfigure/metrics/JobRunrMetricsAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-2-starter/src/main/java/org/jobrunr/spring/autoconfigure/metrics/JobRunrMetricsAutoConfiguration.java
@@ -23,14 +23,14 @@ import org.springframework.context.annotation.Configuration;
 public class JobRunrMetricsAutoConfiguration {
 
     @Bean
-    @ConditionalOnProperty(prefix = "org.jobrunr.jobs.metrics", name = "enabled", havingValue = "true")
+    @ConditionalOnProperty(prefix = "jobrunr.jobs.metrics", name = "enabled", havingValue = "true")
     public StorageProviderMetricsBinder storageProviderMetricsBinder(StorageProvider storageProvider, MeterRegistry meterRegistry) {
         return new StorageProviderMetricsBinder(storageProvider, meterRegistry);
     }
 
     @Bean
     @ConditionalOnBean({BackgroundJobServer.class})
-    @ConditionalOnProperty(prefix = "org.jobrunr.background-job-server.metrics", name = "enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(prefix = "jobrunr.background-job-server.metrics", name = "enabled", havingValue = "true", matchIfMissing = true)
     public BackgroundJobServerMetricsBinder backgroundJobServerMetricsBinder(BackgroundJobServer backgroundJobServer, MeterRegistry meterRegistry) {
         return new BackgroundJobServerMetricsBinder(backgroundJobServer, meterRegistry);
     }

--- a/framework-support/jobrunr-spring-boot-2-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrDocumentDBStorageAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-2-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrDocumentDBStorageAutoConfiguration.java
@@ -20,7 +20,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnBean(MongoClient.class)
 @AutoConfigureAfter(MongoAutoConfiguration.class)
 @AutoConfigureBefore(JobRunrAutoConfiguration.class)
-@ConditionalOnProperty(prefix = "org.jobrunr.database", name = "type", havingValue = "documentdb", matchIfMissing = false)
+@ConditionalOnProperty(prefix = "jobrunr.database", name = "type", havingValue = "documentdb", matchIfMissing = false)
 public class JobRunrDocumentDBStorageAutoConfiguration {
 
     @Bean(name = "storageProvider", destroyMethod = "close")

--- a/framework-support/jobrunr-spring-boot-2-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrInMemoryStorageAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-2-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrInMemoryStorageAutoConfiguration.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @AutoConfigureBefore(JobRunrAutoConfiguration.class)
-@ConditionalOnProperty(prefix = "org.jobrunr.database", name = "type", havingValue = "mem")
+@ConditionalOnProperty(prefix = "jobrunr.database", name = "type", havingValue = "mem")
 public class JobRunrInMemoryStorageAutoConfiguration {
     private static final Logger LOGGER = LoggerFactory.getLogger(JobRunrInMemoryStorageAutoConfiguration.class);
 

--- a/framework-support/jobrunr-spring-boot-2-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrMongoDBStorageAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-2-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrMongoDBStorageAutoConfiguration.java
@@ -20,7 +20,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnBean(MongoClient.class)
 @AutoConfigureAfter(MongoAutoConfiguration.class)
 @AutoConfigureBefore(JobRunrAutoConfiguration.class)
-@ConditionalOnProperty(prefix = "org.jobrunr.database", name = "type", havingValue = "mongodb", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "jobrunr.database", name = "type", havingValue = "mongodb", matchIfMissing = true)
 public class JobRunrMongoDBStorageAutoConfiguration {
 
     @Bean(name = "storageProvider", destroyMethod = "close")

--- a/framework-support/jobrunr-spring-boot-2-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrSqlStorageAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-2-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrSqlStorageAutoConfiguration.java
@@ -25,7 +25,7 @@ import static org.jobrunr.utils.StringUtils.isNotNullOrEmpty;
 @ConditionalOnBean(DataSource.class)
 @AutoConfigureAfter(DataSourceAutoConfiguration.class)
 @AutoConfigureBefore(JobRunrAutoConfiguration.class)
-@ConditionalOnProperty(prefix = "org.jobrunr.database", name = "type", havingValue = "sql", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "jobrunr.database", name = "type", havingValue = "sql", matchIfMissing = true)
 public class JobRunrSqlStorageAutoConfiguration {
 
     @Bean(name = "storageProvider", destroyMethod = "close")

--- a/framework-support/jobrunr-spring-boot-2-starter/src/test/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfigurationTest.java
+++ b/framework-support/jobrunr-spring-boot-2-starter/src/test/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfigurationTest.java
@@ -81,7 +81,7 @@ public class JobRunrAutoConfigurationTest {
 
     @Test
     void jobSchedulerEnabledAutoConfiguration() {
-        this.contextRunner.withPropertyValues("org.jobrunr.job-scheduler.enabled=true").withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
+        this.contextRunner.withPropertyValues("jobrunr.job-scheduler.enabled=true").withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
             assertThat(context).hasSingleBean(JobScheduler.class);
             assertThat(context).hasSingleBean(JobRequestScheduler.class);
             assertThat(context).doesNotHaveBean(JobRunrDashboardWebServer.class);
@@ -91,7 +91,7 @@ public class JobRunrAutoConfigurationTest {
 
     @Test
     void jobSchedulerDisabledAutoConfiguration() {
-        this.contextRunner.withPropertyValues("org.jobrunr.job-scheduler.enabled=false").withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
+        this.contextRunner.withPropertyValues("jobrunr.job-scheduler.enabled=false").withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
             assertThat(context).doesNotHaveBean(JobScheduler.class);
             assertThat(context).doesNotHaveBean(JobRunrDashboardWebServer.class);
             assertThat(context).doesNotHaveBean(BackgroundJobServer.class);
@@ -100,7 +100,7 @@ public class JobRunrAutoConfigurationTest {
 
     @Test
     void dashboardAutoConfiguration() {
-        this.contextRunner.withPropertyValues("org.jobrunr.dashboard.enabled=true").withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
+        this.contextRunner.withPropertyValues("jobrunr.dashboard.enabled=true").withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
             assertThat(context).hasSingleBean(JobRunrDashboardWebServer.class);
             assertThat(context).doesNotHaveBean(BackgroundJobServer.class);
         });
@@ -110,8 +110,8 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void dashboardAutoConfigurationTakesIntoAccountAllowAnonymousDataUsageDefaultTrue() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.dashboard.enabled=true")
-                .withPropertyValues("org.jobrunr.miscellaneous.allow-anonymous-data-usage=true")
+                .withPropertyValues("jobrunr.dashboard.enabled=true")
+                .withPropertyValues("jobrunr.miscellaneous.allow-anonymous-data-usage=true")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context).hasSingleBean(JobRunrDashboardWebServer.class);
                     assertThat(context.getBean(JobRunrDashboardWebServer.class))
@@ -122,8 +122,8 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void dashboardAutoConfigurationTakesIntoAccountAllowAnonymousDataUsageFalse() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.dashboard.enabled=true")
-                .withPropertyValues("org.jobrunr.miscellaneous.allow-anonymous-data-usage=false")
+                .withPropertyValues("jobrunr.dashboard.enabled=true")
+                .withPropertyValues("jobrunr.miscellaneous.allow-anonymous-data-usage=false")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context).hasSingleBean(JobRunrDashboardWebServer.class);
                     assertThat(context.getBean(JobRunrDashboardWebServer.class))
@@ -134,7 +134,7 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void backgroundJobServerAutoConfiguration() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context).hasSingleBean(BackgroundJobServer.class);
                     assertThat(context).doesNotHaveBean(JobRunrDashboardWebServer.class);
@@ -144,8 +144,8 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void backgroundJobServerAutoConfigurationTakesIntoAccountName() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
-                .withPropertyValues("org.jobrunr.background-job-server.name=test")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.name=test")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context).hasSingleBean(BackgroundJobServer.class);
                     assertThat(context.getBean(BackgroundJobServer.class))
@@ -156,9 +156,9 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void backgroundJobServerAutoConfigurationTakesIntoThreadTypeAndWorkerCount() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
-                .withPropertyValues("org.jobrunr.background-job-server.worker-count=4")
-                .withPropertyValues("org.jobrunr.background-job-server.thread-type=PlatformThreads")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.worker-count=4")
+                .withPropertyValues("jobrunr.background-job-server.thread-type=PlatformThreads")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context).hasSingleBean(BackgroundJobServer.class);
                     assertThat(context.getBean(BackgroundJobServerConfiguration.class))
@@ -169,9 +169,9 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void backgroundJobServerAutoConfigurationTakesPollIntervalInSecondsAndServerTimeoutPollIntervalMultiplicand() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
-                .withPropertyValues("org.jobrunr.background-job-server.poll-interval-in-seconds=5")
-                .withPropertyValues("org.jobrunr.background-job-server.server-timeout-poll-interval-multiplicand=10")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.poll-interval-in-seconds=5")
+                .withPropertyValues("jobrunr.background-job-server.server-timeout-poll-interval-multiplicand=10")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context).hasSingleBean(BackgroundJobServer.class);
                     assertThat(context.getBean(BackgroundJobServerConfiguration.class))
@@ -183,8 +183,8 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void backgroundJobServerAutoConfigurationTakesIntoAccountDefaultNumberOfRetries() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
-                .withPropertyValues("org.jobrunr.jobs.default-number-of-retries=3")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.jobs.default-number-of-retries=3")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context).hasSingleBean(BackgroundJobServer.class);
                     assertThat(context.getBean(BackgroundJobServer.class))
@@ -195,10 +195,10 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void backgroundJobServerAutoConfigurationTakesIntoAccountAllJobsRequestSizes() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
-                .withPropertyValues("org.jobrunr.background-job-server.scheduled-jobs-request-size=1")
-                .withPropertyValues("org.jobrunr.background-job-server.orphaned-jobs-request-size=2")
-                .withPropertyValues("org.jobrunr.background-job-server.succeeded-jobs-request-size=3")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.scheduled-jobs-request-size=1")
+                .withPropertyValues("jobrunr.background-job-server.orphaned-jobs-request-size=2")
+                .withPropertyValues("jobrunr.background-job-server.succeeded-jobs-request-size=3")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context.getBean(BackgroundJobServerConfiguration.class))
                             .hasScheduledJobRequestSize(1)
@@ -210,8 +210,8 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void backgroundJobServerAutoConfigurationTakesIntoAccountInterruptJobsAwaitDurationOnStopBackgroundJobServer() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
-                .withPropertyValues("org.jobrunr.background-job-server.interrupt_jobs_await_duration_on_stop=20")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.interrupt_jobs_await_duration_on_stop=20")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context.getBean(BackgroundJobServerConfiguration.class))
                             .hasInterruptJobsAwaitDurationOnStopBackgroundJobServer(Duration.ofSeconds(20));
@@ -221,7 +221,7 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void backgroundJobServerAutoConfigurationTakesIntoAccountCustomBackgroundJobServerWorkerPolicy() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
                 .withUserConfiguration(BackgroundJobServerConfigurationWithCustomWorkerPolicy.class, InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context.getBean(BackgroundJobServerConfiguration.class))
                             .hasWorkerPolicyOfType(BackgroundJobServerConfigurationWithCustomWorkerPolicy.MyBackgroundJobServerWorkerPolicy.class);
@@ -238,7 +238,7 @@ public class JobRunrAutoConfigurationTest {
 
     @Test
     void sqlStorageProviderAutoConfiguration() {
-        this.contextRunner.withPropertyValues("org.jobrunr.database.skip-create=true").withUserConfiguration(SqlDataSourceConfiguration.class).run((context) -> {
+        this.contextRunner.withPropertyValues("jobrunr.database.skip-create=true").withUserConfiguration(SqlDataSourceConfiguration.class).run((context) -> {
             assertThat(context).hasSingleBean(DefaultSqlStorageProvider.class);
             assertThat(context.getBean("storageProvider")).extracting("jobMapper").isNotNull();
             assertThat(context).hasSingleBean(JobScheduler.class);
@@ -258,8 +258,8 @@ public class JobRunrAutoConfigurationTest {
     void jobRunrDoesNotFailIfMultipleDatabasesAvailableAndValueConfigured() {
         this.contextRunner
                 .withPropertyValues(
-                        "org.jobrunr.database.skip-create=true",
-                        "org.jobrunr.database.type=sql"
+                        "jobrunr.database.skip-create=true",
+                        "jobrunr.database.type=sql"
                 )
                 .withUserConfiguration(SqlDataSourceConfiguration.class, MongoDBStorageProviderConfiguration.class).run((context) -> {
                     assertThat(context).hasSingleBean(DefaultSqlStorageProvider.class);
@@ -270,7 +270,7 @@ public class JobRunrAutoConfigurationTest {
 
     @Test
     void jobRunrHealthIndicatorAutoConfiguration() {
-        this.contextRunner.withPropertyValues("org.jobrunr.background-job-server.enabled=true").withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
+        this.contextRunner.withPropertyValues("jobrunr.background-job-server.enabled=true").withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
             assertThat(context).hasSingleBean(JobRunrHealthIndicator.class);
             assertThat(context.getBean(JobRunrHealthIndicator.class).health().getStatus()).isEqualTo(Status.UP);
         });
@@ -280,7 +280,7 @@ public class JobRunrAutoConfigurationTest {
     void jobRunrHealthIndicatorAutoConfigurationHealthIndicatorDisabled() {
         this.contextRunner
                 .withPropertyValues(
-                        "org.jobrunr.background-job-server.enabled=true",
+                        "jobrunr.background-job-server.enabled=true",
                         "management.health.jobrunr.enabled=false"
                 )
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {

--- a/framework-support/jobrunr-spring-boot-2-starter/src/test/java/org/jobrunr/spring/autoconfigure/metric/JobRunrMetricsAutoConfigurationTest.java
+++ b/framework-support/jobrunr-spring-boot-2-starter/src/test/java/org/jobrunr/spring/autoconfigure/metric/JobRunrMetricsAutoConfigurationTest.java
@@ -51,7 +51,7 @@ public class JobRunrMetricsAutoConfigurationTest {
     void backgroundJobServerMetricsAreAutoConfiguredAndStorageProviderMetricsAreDisabled() {
         this.contextRunner
                 .withUserConfiguration(InMemoryStorageProvider.class)
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
                 .withBean(SimpleMeterRegistry.class)
                 .run((context) -> {
                     assertThat(context).doesNotHaveBean(StorageProviderMetricsBinder.class);
@@ -63,7 +63,7 @@ public class JobRunrMetricsAutoConfigurationTest {
     void backgroundJobServerMetricsBinderIsIgnoredIfBackgroundJobServerIsNotPresent() {
         this.contextRunner
                 .withUserConfiguration(InMemoryStorageProvider.class)
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=false")
+                .withPropertyValues("jobrunr.background-job-server.enabled=false")
                 .withBean(SimpleMeterRegistry.class)
                 .run((context) -> {
                     assertThat(context).doesNotHaveBean(BackgroundJobServerMetricsBinder.class);
@@ -74,8 +74,8 @@ public class JobRunrMetricsAutoConfigurationTest {
     void storageProviderMetricsBinderAreAutoConfiguredIfJobsMetricsAreEnabled() {
         this.contextRunner
                 .withUserConfiguration(InMemoryStorageProvider.class)
-                .withPropertyValues("org.jobrunr.jobs.metrics.enabled=true")
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.jobs.metrics.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
                 .withBean(SimpleMeterRegistry.class)
                 .run((context) -> {
                     assertThat(context).hasSingleBean(StorageProviderMetricsBinder.class);
@@ -87,8 +87,8 @@ public class JobRunrMetricsAutoConfigurationTest {
     void backgroundJobServerMetricsBinderIsIgnoredIfBackgroundJobServerMetricsAreDisabled() {
         this.contextRunner
                 .withUserConfiguration(InMemoryStorageProvider.class)
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
-                .withPropertyValues("org.jobrunr.background-job-server.metrics.enabled=false")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.metrics.enabled=false")
                 .withBean(SimpleMeterRegistry.class)
                 .run((context) -> {
                     assertThat(context).hasSingleBean(BackgroundJobServer.class);

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
@@ -67,7 +67,7 @@ public class JobRunrAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "org.jobrunr.job-scheduler", name = "enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(prefix = "jobrunr.job-scheduler", name = "enabled", havingValue = "true", matchIfMissing = true)
     public JobScheduler jobScheduler(StorageProvider storageProvider, JobRunrProperties properties) {
         final JobDetailsGenerator jobDetailsGenerator = newInstance(properties.getJobScheduler().getJobDetailsGenerator());
         return new JobScheduler(storageProvider, jobDetailsGenerator, emptyList());
@@ -75,14 +75,14 @@ public class JobRunrAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "org.jobrunr.job-scheduler", name = "enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(prefix = "jobrunr.job-scheduler", name = "enabled", havingValue = "true", matchIfMissing = true)
     public JobRequestScheduler jobRequestScheduler(StorageProvider storageProvider) {
         return new JobRequestScheduler(storageProvider, emptyList());
     }
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "org.jobrunr.background-job-server", name = "enabled", havingValue = "true")
+    @ConditionalOnProperty(prefix = "jobrunr.background-job-server", name = "enabled", havingValue = "true")
     public BackgroundJobServer backgroundJobServer(StorageProvider storageProvider, JsonMapper jobRunrJsonMapper, JobActivator jobActivator, BackgroundJobServerConfiguration backgroundJobServerConfiguration, JobRunrProperties properties) {
         final BackgroundJobServer backgroundJobServer = new BackgroundJobServer(storageProvider, jobRunrJsonMapper, jobActivator, backgroundJobServerConfiguration);
         backgroundJobServer.setJobFilters(singletonList(new RetryFilter(properties.getJobs().getDefaultNumberOfRetries(), properties.getJobs().getRetryBackOffTimeSeed())));
@@ -91,7 +91,7 @@ public class JobRunrAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "org.jobrunr.background-job-server", name = "enabled", havingValue = "true")
+    @ConditionalOnProperty(prefix = "jobrunr.background-job-server", name = "enabled", havingValue = "true")
     public BackgroundJobServerWorkerPolicy backgroundJobServerWorkerPolicy(JobRunrProperties properties) {
         JobRunrProperties.BackgroundJobServer backgroundJobServerProperties = properties.getBackgroundJobServer();
         BackgroundJobServerThreadType threadType = ofNullable(backgroundJobServerProperties.getThreadType()).orElse(BackgroundJobServerThreadType.getDefaultThreadType());
@@ -101,7 +101,7 @@ public class JobRunrAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "org.jobrunr.background-job-server", name = "enabled", havingValue = "true")
+    @ConditionalOnProperty(prefix = "jobrunr.background-job-server", name = "enabled", havingValue = "true")
     public BackgroundJobServerConfiguration backgroundJobServerConfiguration(JobRunrProperties properties, BackgroundJobServerWorkerPolicy backgroundJobServerWorkerPolicy) {
         PropertyMapper map = PropertyMapper.get();
         BackgroundJobServerConfiguration backgroundJobServerConfiguration = usingStandardBackgroundJobServerConfiguration();
@@ -124,14 +124,14 @@ public class JobRunrAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "org.jobrunr.dashboard", name = "enabled", havingValue = "true")
+    @ConditionalOnProperty(prefix = "jobrunr.dashboard", name = "enabled", havingValue = "true")
     public JobRunrDashboardWebServer dashboardWebServer(StorageProvider storageProvider, JsonMapper jobRunrJsonMapper, JobRunrDashboardWebServerConfiguration dashboardWebServerConfiguration) {
         return new JobRunrDashboardWebServer(storageProvider, jobRunrJsonMapper, dashboardWebServerConfiguration);
     }
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "org.jobrunr.dashboard", name = "enabled", havingValue = "true")
+    @ConditionalOnProperty(prefix = "jobrunr.dashboard", name = "enabled", havingValue = "true")
     public JobRunrDashboardWebServerConfiguration dashboardWebServerConfiguration(JobRunrProperties properties) {
         return usingStandardDashboardConfiguration()
                 .andPort(properties.getDashboard().getPort())

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrProperties.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrProperties.java
@@ -9,7 +9,7 @@ import org.springframework.boot.convert.DurationUnit;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 
-@ConfigurationProperties(prefix = "org.jobrunr")
+@ConfigurationProperties(prefix = "jobrunr")
 public class JobRunrProperties {
 
     private Database database = new Database();

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/metrics/JobRunrMetricsAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/metrics/JobRunrMetricsAutoConfiguration.java
@@ -21,14 +21,14 @@ import org.springframework.context.annotation.Bean;
 public class JobRunrMetricsAutoConfiguration {
 
     @Bean
-    @ConditionalOnProperty(prefix = "org.jobrunr.jobs.metrics", name = "enabled", havingValue = "true")
+    @ConditionalOnProperty(prefix = "jobrunr.jobs.metrics", name = "enabled", havingValue = "true")
     public StorageProviderMetricsBinder storageProviderMetricsBinder(StorageProvider storageProvider, MeterRegistry meterRegistry) {
         return new StorageProviderMetricsBinder(storageProvider, meterRegistry);
     }
 
     @Bean
     @ConditionalOnBean({BackgroundJobServer.class})
-    @ConditionalOnProperty(prefix = "org.jobrunr.background-job-server.metrics", name = "enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(prefix = "jobrunr.background-job-server.metrics", name = "enabled", havingValue = "true", matchIfMissing = true)
     public BackgroundJobServerMetricsBinder backgroundJobServerMetricsBinder(BackgroundJobServer backgroundJobServer, MeterRegistry meterRegistry) {
         return new BackgroundJobServerMetricsBinder(backgroundJobServer, meterRegistry);
     }

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrDocumentDBStorageAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrDocumentDBStorageAutoConfiguration.java
@@ -16,7 +16,7 @@ import org.springframework.context.annotation.Bean;
 
 @AutoConfiguration(after = MongoAutoConfiguration.class, before = JobRunrAutoConfiguration.class)
 @ConditionalOnBean(MongoClient.class)
-@ConditionalOnProperty(prefix = "org.jobrunr.database", name = "type", havingValue = "documentdb", matchIfMissing = false)
+@ConditionalOnProperty(prefix = "jobrunr.database", name = "type", havingValue = "documentdb", matchIfMissing = false)
 public class JobRunrDocumentDBStorageAutoConfiguration {
 
     @Bean(name = "storageProvider", destroyMethod = "close")

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrInMemoryStorageAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrInMemoryStorageAutoConfiguration.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @AutoConfigureBefore(JobRunrAutoConfiguration.class)
-@ConditionalOnProperty(prefix = "org.jobrunr.database", name = "type", havingValue = "mem")
+@ConditionalOnProperty(prefix = "jobrunr.database", name = "type", havingValue = "mem")
 public class JobRunrInMemoryStorageAutoConfiguration {
     private static final Logger LOGGER = LoggerFactory.getLogger(JobRunrInMemoryStorageAutoConfiguration.class);
 

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrMongoDBStorageAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrMongoDBStorageAutoConfiguration.java
@@ -16,7 +16,7 @@ import org.springframework.context.annotation.Bean;
 
 @AutoConfiguration(after = MongoAutoConfiguration.class, before = JobRunrAutoConfiguration.class)
 @ConditionalOnBean(MongoClient.class)
-@ConditionalOnProperty(prefix = "org.jobrunr.database", name = "type", havingValue = "mongodb", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "jobrunr.database", name = "type", havingValue = "mongodb", matchIfMissing = true)
 public class JobRunrMongoDBStorageAutoConfiguration {
 
     @Bean(name = "storageProvider", destroyMethod = "close")

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrSqlStorageAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/storage/JobRunrSqlStorageAutoConfiguration.java
@@ -21,7 +21,7 @@ import static org.jobrunr.utils.StringUtils.isNotNullOrEmpty;
 
 @AutoConfiguration(after = DataSourceAutoConfiguration.class, before = JobRunrAutoConfiguration.class)
 @ConditionalOnBean(DataSource.class)
-@ConditionalOnProperty(prefix = "org.jobrunr.database", name = "type", havingValue = "sql", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "jobrunr.database", name = "type", havingValue = "sql", matchIfMissing = true)
 public class JobRunrSqlStorageAutoConfiguration {
 
     @Bean(name = "storageProvider", destroyMethod = "close")

--- a/framework-support/jobrunr-spring-boot-3-starter/src/test/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfigurationTest.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/test/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfigurationTest.java
@@ -80,7 +80,7 @@ public class JobRunrAutoConfigurationTest {
 
     @Test
     void jobSchedulerEnabledAutoConfiguration() {
-        this.contextRunner.withPropertyValues("org.jobrunr.job-scheduler.enabled=true").withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
+        this.contextRunner.withPropertyValues("jobrunr.job-scheduler.enabled=true").withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
             assertThat(context).hasSingleBean(JobScheduler.class);
             assertThat(context).hasSingleBean(JobRequestScheduler.class);
             assertThat(context).doesNotHaveBean(JobRunrDashboardWebServer.class);
@@ -90,7 +90,7 @@ public class JobRunrAutoConfigurationTest {
 
     @Test
     void jobSchedulerDisabledAutoConfiguration() {
-        this.contextRunner.withPropertyValues("org.jobrunr.job-scheduler.enabled=false").withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
+        this.contextRunner.withPropertyValues("jobrunr.job-scheduler.enabled=false").withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
             assertThat(context).doesNotHaveBean(JobScheduler.class);
             assertThat(context).doesNotHaveBean(JobRunrDashboardWebServer.class);
             assertThat(context).doesNotHaveBean(BackgroundJobServer.class);
@@ -99,7 +99,7 @@ public class JobRunrAutoConfigurationTest {
 
     @Test
     void dashboardAutoConfiguration() {
-        this.contextRunner.withPropertyValues("org.jobrunr.dashboard.enabled=true").withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
+        this.contextRunner.withPropertyValues("jobrunr.dashboard.enabled=true").withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
             assertThat(context).hasSingleBean(JobRunrDashboardWebServer.class);
             assertThat(context).doesNotHaveBean(BackgroundJobServer.class);
         });
@@ -109,8 +109,8 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void dashboardAutoConfigurationTakesIntoAccountAllowAnonymousDataUsageDefaultTrue() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.dashboard.enabled=true")
-                .withPropertyValues("org.jobrunr.miscellaneous.allow-anonymous-data-usage=true")
+                .withPropertyValues("jobrunr.dashboard.enabled=true")
+                .withPropertyValues("jobrunr.miscellaneous.allow-anonymous-data-usage=true")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context).hasSingleBean(JobRunrDashboardWebServer.class);
                     assertThat(context.getBean(JobRunrDashboardWebServer.class))
@@ -121,8 +121,8 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void dashboardAutoConfigurationTakesIntoAccountAllowAnonymousDataUsageFalse() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.dashboard.enabled=true")
-                .withPropertyValues("org.jobrunr.miscellaneous.allow-anonymous-data-usage=false")
+                .withPropertyValues("jobrunr.dashboard.enabled=true")
+                .withPropertyValues("jobrunr.miscellaneous.allow-anonymous-data-usage=false")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context).hasSingleBean(JobRunrDashboardWebServer.class);
                     assertThat(context.getBean(JobRunrDashboardWebServer.class))
@@ -133,7 +133,7 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void backgroundJobServerAutoConfiguration() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context).hasSingleBean(BackgroundJobServer.class);
                     assertThat(context).doesNotHaveBean(JobRunrDashboardWebServer.class);
@@ -143,8 +143,8 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void backgroundJobServerAutoConfigurationTakesIntoAccountName() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
-                .withPropertyValues("org.jobrunr.background-job-server.name=test")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.name=test")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context).hasSingleBean(BackgroundJobServer.class);
                     assertThat(context.getBean(BackgroundJobServer.class))
@@ -156,9 +156,9 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void backgroundJobServerAutoConfigurationTakesIntoThreadTypeAndWorkerCount() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
-                .withPropertyValues("org.jobrunr.background-job-server.worker-count=4")
-                .withPropertyValues("org.jobrunr.background-job-server.thread-type=PlatformThreads")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.worker-count=4")
+                .withPropertyValues("jobrunr.background-job-server.thread-type=PlatformThreads")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context).hasSingleBean(BackgroundJobServer.class);
                     assertThat(context.getBean(BackgroundJobServerConfiguration.class))
@@ -169,9 +169,9 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void backgroundJobServerAutoConfigurationTakesPollIntervalInSecondsAndServerTimeoutPollIntervalMultiplicand() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
-                .withPropertyValues("org.jobrunr.background-job-server.poll-interval-in-seconds=5")
-                .withPropertyValues("org.jobrunr.background-job-server.server-timeout-poll-interval-multiplicand=10")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.poll-interval-in-seconds=5")
+                .withPropertyValues("jobrunr.background-job-server.server-timeout-poll-interval-multiplicand=10")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context).hasSingleBean(BackgroundJobServer.class);
                     assertThat(context.getBean(BackgroundJobServerConfiguration.class))
@@ -183,8 +183,8 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void backgroundJobServerAutoConfigurationTakesIntoAccountDefaultNumberOfRetries() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
-                .withPropertyValues("org.jobrunr.jobs.default-number-of-retries=3")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.jobs.default-number-of-retries=3")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context).hasSingleBean(BackgroundJobServer.class);
                     assertThat(context.getBean(BackgroundJobServer.class))
@@ -195,10 +195,10 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void backgroundJobServerAutoConfigurationTakesIntoAccountAllJobsRequestSizes() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
-                .withPropertyValues("org.jobrunr.background-job-server.scheduled-jobs-request-size=1")
-                .withPropertyValues("org.jobrunr.background-job-server.orphaned-jobs-request-size=2")
-                .withPropertyValues("org.jobrunr.background-job-server.succeeded-jobs-request-size=3")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.scheduled-jobs-request-size=1")
+                .withPropertyValues("jobrunr.background-job-server.orphaned-jobs-request-size=2")
+                .withPropertyValues("jobrunr.background-job-server.succeeded-jobs-request-size=3")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context.getBean(BackgroundJobServerConfiguration.class))
                             .hasScheduledJobRequestSize(1)
@@ -210,8 +210,8 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void backgroundJobServerAutoConfigurationTakesIntoAccountInterruptJobsAwaitDurationOnStopBackgroundJobServer() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
-                .withPropertyValues("org.jobrunr.background-job-server.interrupt_jobs_await_duration_on_stop=20")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.interrupt_jobs_await_duration_on_stop=20")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context.getBean(BackgroundJobServerConfiguration.class))
                             .hasInterruptJobsAwaitDurationOnStopBackgroundJobServer(Duration.ofSeconds(20));
@@ -221,7 +221,7 @@ public class JobRunrAutoConfigurationTest {
     @Test
     void backgroundJobServerAutoConfigurationTakesIntoAccountCustomBackgroundJobServerWorkerPolicy() {
         this.contextRunner
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
                 .withUserConfiguration(BackgroundJobServerConfigurationWithCustomWorkerPolicy.class, InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context.getBean(BackgroundJobServerConfiguration.class))
                             .hasWorkerPolicyOfType(BackgroundJobServerConfigurationWithCustomWorkerPolicy.MyBackgroundJobServerWorkerPolicy.class);
@@ -238,7 +238,7 @@ public class JobRunrAutoConfigurationTest {
 
     @Test
     void sqlStorageProviderAutoConfiguration() {
-        this.contextRunner.withPropertyValues("org.jobrunr.database.skip-create=true").withUserConfiguration(SqlDataSourceConfiguration.class).run((context) -> {
+        this.contextRunner.withPropertyValues("jobrunr.database.skip-create=true").withUserConfiguration(SqlDataSourceConfiguration.class).run((context) -> {
             assertThat(context).hasSingleBean(DefaultSqlStorageProvider.class);
             assertThat(context.getBean("storageProvider")).extracting("jobMapper").isNotNull();
             assertThat(context).hasSingleBean(JobScheduler.class);
@@ -258,8 +258,8 @@ public class JobRunrAutoConfigurationTest {
     void jobRunrDoesNotFailIfMultipleDatabasesAvailableAndValueConfigured() {
         this.contextRunner
                 .withPropertyValues(
-                        "org.jobrunr.database.skip-create=true",
-                        "org.jobrunr.database.type=sql"
+                        "jobrunr.database.skip-create=true",
+                        "jobrunr.database.type=sql"
                 )
                 .withUserConfiguration(SqlDataSourceConfiguration.class, MongoDBStorageProviderConfiguration.class).run((context) -> {
                     assertThat(context).hasSingleBean(DefaultSqlStorageProvider.class);
@@ -270,7 +270,7 @@ public class JobRunrAutoConfigurationTest {
 
     @Test
     void jobRunrHealthIndicatorAutoConfiguration() {
-        this.contextRunner.withPropertyValues("org.jobrunr.background-job-server.enabled=true").withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
+        this.contextRunner.withPropertyValues("jobrunr.background-job-server.enabled=true").withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
             assertThat(context).hasSingleBean(JobRunrHealthIndicator.class);
             assertThat(context.getBean(JobRunrHealthIndicator.class).health().getStatus()).isEqualTo(Status.UP);
         });
@@ -280,7 +280,7 @@ public class JobRunrAutoConfigurationTest {
     void jobRunrHealthIndicatorAutoConfigurationHealthIndicatorDisabled() {
         this.contextRunner
                 .withPropertyValues(
-                        "org.jobrunr.background-job-server.enabled=true",
+                        "jobrunr.background-job-server.enabled=true",
                         "management.health.jobrunr.enabled=false"
                 )
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {

--- a/framework-support/jobrunr-spring-boot-3-starter/src/test/java/org/jobrunr/spring/autoconfigure/metric/JobRunrMetricsAutoConfigurationTest.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/test/java/org/jobrunr/spring/autoconfigure/metric/JobRunrMetricsAutoConfigurationTest.java
@@ -51,7 +51,7 @@ public class JobRunrMetricsAutoConfigurationTest {
     void backgroundJobServerMetricsAreAutoConfiguredAndStorageProviderMetricsAreDisabled() {
         this.contextRunner
                 .withUserConfiguration(InMemoryStorageProvider.class)
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
                 .withBean(SimpleMeterRegistry.class)
                 .run((context) -> {
                     assertThat(context).doesNotHaveBean(StorageProviderMetricsBinder.class);
@@ -63,7 +63,7 @@ public class JobRunrMetricsAutoConfigurationTest {
     void backgroundJobServerMetricsBinderIsIgnoredIfBackgroundJobServerIsNotPresent() {
         this.contextRunner
                 .withUserConfiguration(InMemoryStorageProvider.class)
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=false")
+                .withPropertyValues("jobrunr.background-job-server.enabled=false")
                 .withBean(SimpleMeterRegistry.class)
                 .run((context) -> {
                     assertThat(context).doesNotHaveBean(BackgroundJobServerMetricsBinder.class);
@@ -74,8 +74,8 @@ public class JobRunrMetricsAutoConfigurationTest {
     void storageProviderMetricsBinderAreAutoConfiguredIfJobsMetricsAreEnabled() {
         this.contextRunner
                 .withUserConfiguration(InMemoryStorageProvider.class)
-                .withPropertyValues("org.jobrunr.jobs.metrics.enabled=true")
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.jobs.metrics.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
                 .withBean(SimpleMeterRegistry.class)
                 .run((context) -> {
                     assertThat(context).hasSingleBean(StorageProviderMetricsBinder.class);
@@ -87,8 +87,8 @@ public class JobRunrMetricsAutoConfigurationTest {
     void backgroundJobServerMetricsBinderIsIgnoredIfBackgroundJobServerMetricsAreDisabled() {
         this.contextRunner
                 .withUserConfiguration(InMemoryStorageProvider.class)
-                .withPropertyValues("org.jobrunr.background-job-server.enabled=true")
-                .withPropertyValues("org.jobrunr.background-job-server.metrics.enabled=false")
+                .withPropertyValues("jobrunr.background-job-server.enabled=true")
+                .withPropertyValues("jobrunr.background-job-server.metrics.enabled=false")
                 .withBean(SimpleMeterRegistry.class)
                 .run((context) -> {
                     assertThat(context).hasSingleBean(BackgroundJobServer.class);

--- a/framework-support/jobrunr-spring-boot-3-starter/src/test/resources/application.properties
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/test/resources/application.properties
@@ -1,2 +1,2 @@
-org.jobrunr.background-job-server.enabled=true
-org.jobrunr.background-job-server.poll-interval-in-seconds=5
+jobrunr.background-job-server.enabled=true
+jobrunr.background-job-server.poll-interval-in-seconds=5


### PR DESCRIPTION
Breaking:

Change property prefix from `org.jobrunr` to `jobrunr`. Example:

`org.jobrunr.background-job-server.enabled=true
` becomes `jobrunr.background-job-server.enabled=true`