### PR TITLE
make PARAM_TYPES_PATTERN final in JobDetailsGeneratorUtils

### DIFF
--- a/core/src/main/java/org/jobrunr/jobs/details/JobDetailsGeneratorUtils.java
+++ b/core/src/main/java/org/jobrunr/jobs/details/JobDetailsGeneratorUtils.java
@@ -19,7 +19,7 @@ import static org.jobrunr.utils.reflection.ReflectionUtils.toClass;
 
 public class JobDetailsGeneratorUtils {
 
-    private static Pattern PARAM_TYPES_PATTERN = Pattern.compile("\\[*L[^;]+;|\\[[ZBCSIFDJ]|[ZBCSIFDJ]"); //Regex for desc \[*L[^;]+;|\[[ZBCSIFDJ]|[ZBCSIFDJ]
+    private static final Pattern PARAM_TYPES_PATTERN = Pattern.compile("\\[*L[^;]+;|\\[[ZBCSIFDJ]|[ZBCSIFDJ]"); //Regex for desc \[*L[^;]+;|\[[ZBCSIFDJ]|[ZBCSIFDJ]
 
     private JobDetailsGeneratorUtils() {
     }


### PR DESCRIPTION
It is a good practise to mark as final static fields that aren't meant to be reassigned
