### PR TITLE
CarbonAware Job Processing - fix layout labeling 

### DIFF
--- a/core/src/main/java/org/jobrunr/server/tasks/zookeeper/ProcessCarbonAwareAwaitingJobsTask.java
+++ b/core/src/main/java/org/jobrunr/server/tasks/zookeeper/ProcessCarbonAwareAwaitingJobsTask.java
@@ -106,7 +106,7 @@ public class ProcessCarbonAwareAwaitingJobsTask extends AbstractJobZooKeeperTask
         } else if (carbonIntensityForecast.hasNoForecastForPeriod(state.getFrom(), state.getTo())) {
             scheduleJobAt(job, state.getFallbackInstant(), state, getReasonForMissingForecast(state));
         } else {
-            scheduleJobAt(job, idealMoment(state), state, "At the best moment to minimize carbon impact.");
+            scheduleJobAt(job, idealMoment(state), state, "At the best moment to minimize carbon impact in " + this.carbonIntensityForecast.getDisplayName() + ".");
         }
     }
 

--- a/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/jobs/job-view.js
+++ b/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/jobs/job-view.js
@@ -28,6 +28,7 @@ import {jobStateToHumanReadableName} from "../utils/job-utils";
 import SucceededNotification from "./notifications/succeeded-notification";
 import DeletedNotification from "./notifications/deleted-notification";
 import JobDetailsNotCacheableNotification from "./notifications/job-details-not-cacheable-notification";
+import CarbonAwareScheduledNotification from "./notifications/carbon-aware-scheduled-notification";
 import VersionFooter from "../utils/version-footer";
 import JobLabel from "../utils/job-label";
 import {ItemsNotFound} from "../utils/items-not-found";
@@ -188,6 +189,7 @@ const JobView = (props) => {
                             {job.jobDetails.cacheable === false && <JobDetailsNotCacheableNotification job={job}/>}
                             {stateBreadcrumb.state === 'SUCCEEDED' && <SucceededNotification job={job}/>}
                             {stateBreadcrumb.state === 'DELETED' && <DeletedNotification job={job}/>}
+                            {stateBreadcrumb.state === 'SCHEDULED' && <CarbonAwareScheduledNotification job={job}/>}
 
                             <Grid item xs={12}>
                                 <Typography variant="h5" component="h2">

--- a/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/jobs/notifications/carbon-aware-scheduled-notification.js
+++ b/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/jobs/notifications/carbon-aware-scheduled-notification.js
@@ -1,0 +1,27 @@
+import {JobNotification} from "./job-notification";
+import {EnergySavingsLeaf} from "@mui/icons-material";
+import Grid from "@mui/material/Grid";
+import Paper from "@mui/material/Paper";
+import Alert from "@mui/material/Alert";
+import {SwitchableTimeAgo} from "../../utils/time-ago";
+
+const CarbonAwareScheduledNotification = ({job}) => {
+    const awaitingState = job.jobHistory[0];
+    if(awaitingState["@class"].indexOf("CarbonAwareAwaitingState") === -1) {
+        return;
+    }
+
+    return (
+        <Grid item xs={12}>
+            <Paper>
+                <Alert severity="info" icon={
+                    <EnergySavingsLeaf fontSize="small" color="success" style={{marginRight: "4px"}}/>
+                } style={{fontSize: '1rem'}}>
+                    This job is scheduled Carbon Aware between <SwitchableTimeAgo date={new Date(awaitingState.from)}/> and <SwitchableTimeAgo date={new Date(awaitingState.to)}/> to minimize carbon impact.
+                </Alert>
+            </Paper>
+        </Grid>
+    )
+};
+
+export default CarbonAwareScheduledNotification;

--- a/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/jobs/states/scheduled-state.js
+++ b/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/jobs/states/scheduled-state.js
@@ -2,7 +2,7 @@ import {JobState} from "./job-state";
 
 const Scheduled = ({jobState}) => {
     const scheduledDate = new Date(jobState.scheduledAt);
-    const title = "Job Scheduled" + (jobState.reason ? `- ${jobState.reason}` : "");
+    const title = "Job Scheduled " + (jobState.reason ? `- ${jobState.reason}` : "");
 
     return (
         <JobState state="scheduled" title={title} date={jobState.scheduledAt}>

--- a/core/src/test/java/org/jobrunr/server/tasks/zookeeper/ProcessCarbonAwareAwaitingJobsTaskTest.java
+++ b/core/src/test/java/org/jobrunr/server/tasks/zookeeper/ProcessCarbonAwareAwaitingJobsTaskTest.java
@@ -96,7 +96,7 @@ class ProcessCarbonAwareAwaitingJobsTaskTest extends AbstractTaskTest {
             verify(carbonIntensityApiClient(task)).fetchCarbonIntensityForecast();
             assertThatJob(job)
                     .hasStates(AWAITING, SCHEDULED)
-                    .hasScheduledAt(now().plus(1, HOURS).truncatedTo(HOURS), "At the best moment to minimize carbon impact.");
+                    .hasScheduledAt(now().plus(1, HOURS).truncatedTo(HOURS), "At the best moment to minimize carbon impact in MOCK_AREA.");
         }
     }
 
@@ -383,7 +383,7 @@ class ProcessCarbonAwareAwaitingJobsTaskTest extends AbstractTaskTest {
             // THEN
             assertThatJob(job)
                     .hasStates(AWAITING, SCHEDULED)
-                    .hasScheduledAt(parse("2025-05-20T12:00:00.000Z"), "At the best moment to minimize carbon impact.");
+                    .hasScheduledAt(parse("2025-05-20T12:00:00.000Z"), "At the best moment to minimize carbon impact in Italy.");
         }
     }
 


### PR DESCRIPTION
Fixes:

- The space in the job history

Adds:

- The region in the reason when scheduling a carbon aware job
- A carbon aware information popup in the job detail page when scheduling a carbon aware job

![Screenshot 2025-06-24 at 15 44 30](https://github.com/user-attachments/assets/d4fa267f-6c4a-4d96-b0b9-f17cdaaa3242)
