### PR TITLE
refactor the ossrh staging api sed json extration into a proper Grald…

### DIFF
--- a/.woodpecker/release.yaml
+++ b/.woodpecker/release.yaml
@@ -21,17 +21,8 @@ steps:
       - |
         bash -lc '
           set -e -o pipefail
-          gradle --no-daemon -Djib.console=plain --info clean assemble publishToSonatype \
+          gradle --no-daemon -Djib.console=plain --info clean assemble publishToSonatype nexusPushFromStagingToCentral \
             | grep -Ev "^(Found locally available resource with matching checksum|BuildToolsApiClasspathEntrySnapshotTransform|ClasspathEntrySnapshotTransform|Resource missing\\.)"
-        '
-      - |
-        bash -lc '
-          SONATYPE_OUT=$(curl -sS -X GET -H "$SONATYPE_AUTH_HEADER" https://ossrh-staging-api.central.sonatype.com/manual/search/repositories\?profile_id\=org.jobrunr\&state\=open\&ip\=any)
-          echo "Sonatype Saging API: Received JSON $SONATYPE_OUT"
-          SONATYPE_KEY=$(echo "$SONATYPE_OUT" | grep "key" | sed "s/\"key\": \"//" | sed "s/\",//" | tr -d " ")
-          echo "Sonatype OSSRH Staging API Repository key $SONATYPE_KEY found"
-          curl -X POST -H "$SONATYPE_AUTH_HEADER" https://ossrh-staging-api.central.sonatype.com/manual/upload/repository/$SONATYPE_KEY
-          echo "Sonatype Upload from Staging API to Portal complete. Go to https://central.sonatype.com/publishing/deployments to finish the release."
         '
     environment:
       BUILD_CACHE_USER:

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import groovy.json.JsonSlurper
+
 plugins {
     id 'com.github.ben-manes.versions' version '0.51.0'
     id 'org.sonarqube' version '4.4.1.3373'
@@ -13,6 +15,40 @@ nexusPublishing {
             nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
             snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
+    }
+}
+
+task nexusPushFromStagingToCentral {
+    doLast {
+        if(System.getenv("SONATYPE_AUTH_HEADER") == null) {
+            throw new GradleException("Cannot push Sonatype Nexus artifacts to Portal API: env var SONATYPE_AUTH_HEADER is not set")
+        }
+
+        println("Retrieving uploaded OSSRH Staging API repository key...")
+        def get = new URL("https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?profile_id=org.jobrunr&state=open&ip=any").openConnection();
+        get.setRequestProperty("Authorization", System.getenv("SONATYPE_AUTH_HEADER"))
+        def resp = get.getInputStream().getText();
+        def json = new JsonSlurper().parseText(resp)
+
+        if(!get.getResponseCode().equals(200)) {
+            throw new GradleException("Cannot find repository key from Sonatype OSSRH Staging API: received code " + get.getResponseCode())
+        }
+        if(json.repositories == null || json.repositories[0] == null) {
+            throw new GradleException("Cannot find repository key from Sonatype OSSRH Staging API: no key returned, is the publication done? received json " + json)
+        }
+        def repoKey = json.repositories[0].key
+        println("-- Found Repo Key " + repoKey)
+
+        println("Uploading from OSSRH Staging API to Central Portal using retrieved key...")
+        def post = new URL("https://ossrh-staging-api.central.sonatype.com/manual/upload/repository/" + repoKey).openConnection();
+        post.setRequestProperty("Authorization", System.getenv("SONATYPE_AUTH_HEADER"))
+        post.setRequestMethod("POST")
+        post.setDoOutput(true)
+
+        if(!post.getResponseCode().equals(200)) {
+            throw new GradleException("Cannot push artifacts from staging API to Portal API: received code " + post.getResponseCode() + " - please log into https://central.sonatype.com/ to investigate what went wrong.")
+        }
+        println("-- Successfully pushed Sonatype Nexus artifacts to Portal API: please log into https://central.sonatype.com/ to finish the release.")
     }
 }
 
@@ -77,6 +113,7 @@ configure(subprojects.findAll { !['platform'].contains(it.name) }) {
 
     dependencies {
         implementation platform(project(':platform'))
+        implementation 'org.apache.groovy:groovy-json:4.0.27'
 
         testImplementation 'org.junit.jupiter:junit-jupiter'
         testImplementation 'io.github.artsok:rerunner-jupiter'


### PR DESCRIPTION
Fixes task "CI: Fix Sonatype Auto-release script" 

Reworked the sed json extration for Sonatype OSSRH staging releasing into a proper Gradle script. 

Locally tested with 

```
CI_COMMIT_TAG="v0.0.1" SONATYPE_AUTH_HEADER="Bearer [token]" ORG_GRADLE_PROJECT_sonatypeUsername="[user]" ORG_GRADLE_PROJECT_sonatypePassword="[pass]" ./gradlew clean assemble publishToSonatype nexusPushFromStagingToCentral
```
Returns a `400` as expected if signing does not work. Throws timely exceptions, makes error handling more verbose.
