### PR TITLE
Hotfix: v8 RecurringJob#createdBy breaks kotlinx.serialization

### DIFF
--- a/language-support/jobrunr-kotlin-21-support/src/main/kotlin/org/jobrunr/kotlin/serialization/jobs/RecurringJobSerializer.kt
+++ b/language-support/jobrunr-kotlin-21-support/src/main/kotlin/org/jobrunr/kotlin/serialization/jobs/RecurringJobSerializer.kt
@@ -32,7 +32,7 @@ object RecurringJobSerializer : KSerializer<RecurringJob>, ClassDiscriminatedCon
         element("jobDetails", JobDetailsSerializer.descriptor)
         element("scheduleExpression", String.serializer().descriptor)
         element("zoneId", String.serializer().descriptor)
-        element("createdBy", createdByDescriptor)
+        element("createdBy", createdByDescriptor, isOptional = true)
         element("createdAt", InstantSerializer.descriptor)
     }
 
@@ -54,7 +54,7 @@ object RecurringJobSerializer : KSerializer<RecurringJob>, ClassDiscriminatedCon
         encodeSerializableElement(descriptor, 6, JobDetailsSerializer, value.jobDetails)
         encodeStringElement(descriptor, 7, value.scheduleExpression)
         encodeStringElement(descriptor, 8, value.zoneId)
-        encodeStringElement(descriptor, 9, value.createdBy.name)
+        value.createdBy?.name?.let { encodeStringElement(descriptor, 9, it) }
         encodeSerializableElement(descriptor, 10, InstantSerializer, value.createdAt)
     }
 

--- a/language-support/jobrunr-kotlin-22-support/src/main/kotlin/org/jobrunr/kotlin/serialization/jobs/RecurringJobSerializer.kt
+++ b/language-support/jobrunr-kotlin-22-support/src/main/kotlin/org/jobrunr/kotlin/serialization/jobs/RecurringJobSerializer.kt
@@ -32,7 +32,7 @@ object RecurringJobSerializer : KSerializer<RecurringJob>, ClassDiscriminatedCon
         element("jobDetails", JobDetailsSerializer.descriptor)
         element("scheduleExpression", String.serializer().descriptor)
         element("zoneId", String.serializer().descriptor)
-        element("createdBy", createdByDescriptor)
+        element("createdBy", createdByDescriptor, isOptional = true)
         element("createdAt", InstantSerializer.descriptor)
     }
 
@@ -54,7 +54,7 @@ object RecurringJobSerializer : KSerializer<RecurringJob>, ClassDiscriminatedCon
         encodeSerializableElement(descriptor, 6, JobDetailsSerializer, value.jobDetails)
         encodeStringElement(descriptor, 7, value.scheduleExpression)
         encodeStringElement(descriptor, 8, value.zoneId)
-        encodeStringElement(descriptor, 9, value.createdBy.name)
+        value.createdBy?.name?.let { encodeStringElement(descriptor, 9, it) }
         encodeSerializableElement(descriptor, 10, InstantSerializer, value.createdAt)
     }
 


### PR DESCRIPTION
In 56bc132 (due to be released as part of v8), the `createdBy` field was added to the `RecurringJob` class. Unfortunately, during the implementation of the serializer, it was overlooked that this field does not have a default and is therefore nullable.

With this, one of my fears regarding the ad-hoc approach of the Kotlin code to Java became true: nullability concerns. Ideally, we should verify that all non-null assumptions are correct before opening the flood gates. On the other hand, compatibility with other JobMappers is explicitly not guaranteed in the release notes. I tried running this fix against my v7.5.1 state and haven't found any other incompatibilities.