### PR TITLE
[NO-TASK] Performs deletion in smaller batches.

### DIFF
--- a/core/src/main/java/org/jobrunr/storage/sql/common/JobTable.java
+++ b/core/src/main/java/org/jobrunr/storage/sql/common/JobTable.java
@@ -191,7 +191,7 @@ public class JobTable extends Sql<Job> {
     public int deleteJobsByStateAndUpdatedBefore(StateName state, Instant updatedBefore) throws SQLException {
         return withState(state)
                 .withUpdatedBefore(updatedBefore)
-                .delete("from jobrunr_jobs where state = :state AND updatedAt <= :updatedBefore");
+                .delete("from jobrunr_jobs where state = :state AND updatedAt <= :updatedBefore limit 100");
     }
 
     void insertOneJob(Job jobToSave) throws SQLException {


### PR DESCRIPTION
When a high number of jobs are scheduled within a short timeframe, there's typically a corresponding spike, in this deletion operation, of the number of rows to remove. 

The database resources can be overwhelmed and leave the transaction open for longer than expecting, creating a chain of performance issues. 

To improve the general performance, I updated the code to create smaller batches that are committed more frequently.

> [!NOTE]
> At the moment, this is a draft. I'm mostly looking for guidance on what you're expecting. For example: should the batch be something consumers can customize? Should 