### PR TITLE
Add extra job stats for Kotlin+JobStatsSSE Test

### DIFF
--- a/core/src/test/java/org/jobrunr/dashboard/sse/JacksonJobStatsSseExchangeTest.java
+++ b/core/src/test/java/org/jobrunr/dashboard/sse/JacksonJobStatsSseExchangeTest.java
@@ -1,0 +1,12 @@
+package org.jobrunr.dashboard.sse;
+
+import org.jobrunr.utils.mapper.JsonMapper;
+import org.jobrunr.utils.mapper.jackson.JacksonJsonMapper;
+
+public class JacksonJobStatsSseExchangeTest extends AbstractJobStatsSseExchangeTest {
+
+    @Override
+    protected JsonMapper jsonMapper() {
+        return new JacksonJsonMapper();
+    }
+}

--- a/core/src/testFixtures/java/org/jobrunr/dashboard/sse/AbstractJobStatsSseExchangeTest.java
+++ b/core/src/testFixtures/java/org/jobrunr/dashboard/sse/AbstractJobStatsSseExchangeTest.java
@@ -1,0 +1,87 @@
+package org.jobrunr.dashboard.sse;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import org.jobrunr.jobs.mappers.JobMapper;
+import org.jobrunr.storage.InMemoryStorageProvider;
+import org.jobrunr.storage.StorageProvider;
+import org.jobrunr.utils.mapper.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jobrunr.JobRunrAssertions.contentOfResource;
+import static org.jobrunr.jobs.JobTestBuilder.aDeletedJob;
+import static org.jobrunr.jobs.JobTestBuilder.aFailedJob;
+import static org.jobrunr.jobs.JobTestBuilder.aJobInProgress;
+import static org.jobrunr.jobs.JobTestBuilder.aScheduledJob;
+import static org.jobrunr.jobs.JobTestBuilder.aSucceededJob;
+import static org.mockito.InstantMocker.FIXED_INSTANT_RIGHT_AFTER_THE_HOUR;
+import static org.mockito.InstantMocker.mockTime;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public abstract class AbstractJobStatsSseExchangeTest {
+    private ByteArrayOutputStream outStream;
+    private StorageProvider storageProvider;
+
+    @Mock
+    private HttpExchange httpExchange;
+
+    @BeforeEach
+    void setUp() {
+        this.storageProvider = getStorageProvider();
+        saveTestJobs();
+
+        this.outStream = new ByteArrayOutputStream();
+        when(httpExchange.getResponseBody()).thenReturn(outStream);
+        when(httpExchange.getResponseHeaders()).thenReturn(new Headers());
+    }
+
+    @Test
+    void onChangeSendsJobStats() throws IOException {
+        try (var ignored = mockTime(FIXED_INSTANT_RIGHT_AFTER_THE_HOUR)) {
+            var sseExchange = new JobStatsSseExchange(httpExchange, storageProvider, jsonMapper());
+            outStream.reset();
+
+            sseExchange.onChange(storageProvider.getJobStats());
+            var eventData = outStream.toString(StandardCharsets.UTF_8);
+
+            assertThat(eventData.trim()).isEqualTo(contentOfResource("/dashboard/sse/job-stats.txt"));
+        }
+    }
+
+    protected abstract JsonMapper jsonMapper();
+
+    private StorageProvider getStorageProvider() {
+        var storageProvider = new InMemoryStorageProvider();
+        storageProvider.setJobMapper(new JobMapper(jsonMapper()));
+        return storageProvider;
+    }
+
+    private void saveTestJobs() {
+        // special save to test all-time-succeeded
+        storageProvider.save(aSucceededJob().withDeletedState().build());
+        storageProvider.save(asList(
+                aSucceededJob().withDeletedState().build(),
+                aSucceededJob().withDeletedState().build()));
+
+        // all other jobs
+        storageProvider.save(asList(
+                aJobInProgress().build(),
+                aScheduledJob().build(),
+                aFailedJob().build(),
+                aFailedJob().build(),
+                aSucceededJob().build(),
+                aDeletedJob().build()
+        ));
+    }
+}

--- a/core/src/testFixtures/java/org/mockito/InstantMocker.java
+++ b/core/src/testFixtures/java/org/mockito/InstantMocker.java
@@ -11,6 +11,7 @@ public class InstantMocker {
     public static final Instant FIXED_INSTANT_RIGHT_BEFORE_THE_HOUR = Instant.parse("2022-12-13T13:59:58Z");
     public static final Instant FIXED_INSTANT_RIGHT_BEFORE_THE_MINUTE = Instant.parse("2022-12-14T08:35:55.500Z");
     public static final Instant FIXED_INSTANT_RIGHT_ON_THE_MINUTE = Instant.parse("2022-12-14T08:36:00.005Z");
+    public static final Instant FIXED_INSTANT_RIGHT_AFTER_THE_HOUR = Instant.parse("2022-12-13T14:00:15Z");
 
     public static MockedStatic<Instant> mockTime(String instantAsString) {
         return mockTime(Instant.parse(instantAsString));

--- a/core/src/testFixtures/resources/dashboard/sse/job-stats.txt
+++ b/core/src/testFixtures/resources/dashboard/sse/job-stats.txt
@@ -1,0 +1,2 @@
+event
+data: {"timeStamp":"2022-12-13T14:00:15Z","queryDurationInMillis":0,"total":9,"awaiting":0,"scheduled":1,"enqueued":0,"processing":1,"failed":2,"succeeded":1,"allTimeSucceeded":0,"deleted":4,"recurringJobs":0,"backgroundJobServers":0}

--- a/language-support/jobrunr-kotlin-21-support/src/test/kotlin/org/jobrunr/dashboard/sse/KotlinxSerialisationJobStatsSseExchangeTest.kt
+++ b/language-support/jobrunr-kotlin-21-support/src/test/kotlin/org/jobrunr/dashboard/sse/KotlinxSerialisationJobStatsSseExchangeTest.kt
@@ -1,0 +1,11 @@
+package org.jobrunr.dashboard.sse
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import org.jobrunr.kotlin.utils.mapper.KotlinxSerializationJsonMapper
+import org.jobrunr.utils.mapper.JsonMapper
+
+class KotlinxSerialisationJobStatsSseExchangeTest : AbstractJobStatsSseExchangeTest() {
+    @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
+    override fun jsonMapper(): JsonMapper = KotlinxSerializationJsonMapper()
+}

--- a/language-support/jobrunr-kotlin-22-support/src/test/kotlin/org/jobrunr/dashboard/sse/KotlinxSerialisationJobStatsSseExchangeTest.kt
+++ b/language-support/jobrunr-kotlin-22-support/src/test/kotlin/org/jobrunr/dashboard/sse/KotlinxSerialisationJobStatsSseExchangeTest.kt
@@ -1,0 +1,11 @@
+package org.jobrunr.dashboard.sse
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import org.jobrunr.kotlin.utils.mapper.KotlinxSerializationJsonMapper
+import org.jobrunr.utils.mapper.JsonMapper
+
+class KotlinxSerialisationJobStatsSseExchangeTest : AbstractJobStatsSseExchangeTest() {
+    @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
+    override fun jsonMapper(): JsonMapper = KotlinxSerializationJsonMapper()
+}


### PR DESCRIPTION
We recently encountered issues with SSE JobStat serialization for the new kotlinx serialization functionality. Tests covering all cases are not yet present in this repository, which is what this PR is fixing. 