### PR TITLE
Fixes jobdetail view crash due to Carbonchart + SSE

### DIFF
--- a/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/jobs/states/awaiting-state-carbon-intensity-chart.js
+++ b/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/jobs/states/awaiting-state-carbon-intensity-chart.js
@@ -24,12 +24,11 @@ const CarbonIntensityChart = ({job, jobState}) => {
         [job.jobHistory]
     );
 
-    if (!scheduledState) return null;
-
     const [intensityData, setIntensityData] = useState(null);
     const [notFound, setNotFound] = useState(false);
 
     useEffect(() => {
+        if (!scheduledState) return;
         const ownerDate = extractDateFromISOString(scheduledState.scheduledAt, useUTC);
         fetch(`/api/metadata/carbon-intensity-forecast/${ownerDate}?format=jsonValue`)
             .then(async r => {
@@ -148,6 +147,8 @@ const CarbonIntensityChart = ({job, jobState}) => {
     } else if (!normalized) {
         return null;
     }
+
+    if (!scheduledState) return <div/>;
 
     return (
         <div style={{width: '100%', marginTop: '32px'}}>


### PR DESCRIPTION
This PR fixes the frontend crash due to "react Uncaught Error: Rendered more hooks than during the previous render."

How to reproduce:

- Start JobRunr with carbon aware processing enabled
- Make sure a carbon aware job is created with a bit of delay
- go to the dashboard when it is still carbon aware / pending and wait for the SSE event
- once the SSE event comes in with the new state, the screen crashes

We did a conditional early return causing sometimes hooks like `useEffect()` not to trigger messing up the React render state. These checks should be INSIDE the hook, or just before returning as per https://react.dev/warnings/invalid-hook-call-warning. 