### PR TITLE
improve carbon aware scheduled message in case of disabled config

### DIFF
--- a/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/jobs/job-view.js
+++ b/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/jobs/job-view.js
@@ -24,7 +24,7 @@ import NavigateNextIcon from "@mui/icons-material/NavigateNext";
 import Breadcrumbs from "@mui/material/Breadcrumbs";
 import Box from "@mui/material/Box";
 import LoadingIndicator from "../LoadingIndicator";
-import {getJobMostRecentState, getJobPreviousState, jobStateToHumanReadableName} from "../utils/job-utils";
+import {jobStateToHumanReadableName} from "../utils/job-utils";
 import SucceededNotification from "./notifications/succeeded-notification";
 import DeletedNotification from "./notifications/deleted-notification";
 import JobDetailsNotCacheableNotification from "./notifications/job-details-not-cacheable-notification";
@@ -189,8 +189,8 @@ const JobView = (props) => {
                             {job.jobDetails.cacheable === false && <JobDetailsNotCacheableNotification job={job}/>}
                             {stateBreadcrumb.state === 'SUCCEEDED' && <SucceededNotification job={job}/>}
                             {stateBreadcrumb.state === 'DELETED' && <DeletedNotification job={job}/>}
-                            {stateBreadcrumb.state === 'SCHEDULED' && <CarbonAwareScheduledNotification state={getJobPreviousState(job)}/>}
-                            {stateBreadcrumb.state === 'AWAITING' && <CarbonAwareScheduledNotification state={getJobMostRecentState(job)}/>}
+                            {stateBreadcrumb.state === 'SCHEDULED' && <CarbonAwareScheduledNotification job={job}/>}
+                            {stateBreadcrumb.state === 'AWAITING' && <CarbonAwareScheduledNotification job={job}/>}
 
                             <Grid item xs={12}>
                                 <Typography variant="h5" component="h2">

--- a/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/jobs/notifications/carbon-aware-scheduled-notification.js
+++ b/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/jobs/notifications/carbon-aware-scheduled-notification.js
@@ -1,17 +1,34 @@
 import {EnergySavingsLeaf} from "@mui/icons-material";
-import {SwitchableTimeRangeFormatter} from "../../utils/time-ago";
-import {isCarbonAwaitingState} from "../../utils/job-utils";
+import {SwitchableTimeFormatter, SwitchableTimeRangeFormatter} from "../../utils/time-ago";
 import {JobNotification} from "./job-notification";
 
-const CarbonAwareScheduledNotification = ({state}) => {
-    if (!isCarbonAwaitingState(state)) return;
+const CarbonAwareScheduledNotification = ({job}) => {
+    const carbonAwareAwaitingState = job?.jobHistory?.find(h => h["@class"].endsWith("CarbonAwareAwaitingState"));
+    if (!carbonAwareAwaitingState) return;
+    const scheduledState = job.jobHistory.find(h => h.state === "SCHEDULED");
+
+    function carbonAwareSchedulingDisabled() {
+        return scheduledState?.reason.indexOf("Carbon aware scheduling is disabled") >= 0;
+    }
+
+    if(carbonAwareSchedulingDisabled()) {
+        return (
+            <JobNotification
+                severity="info"
+                icon={<EnergySavingsLeaf fontSize="small" color="success"/>}
+            >
+                This job is scheduled Carbon Aware but Carbon Aware Processing is disabled: scheduling at <SwitchableTimeFormatter date={new Date(scheduledState.scheduledAt)}/>.
+            </JobNotification>
+
+        )
+    }
 
     return (
         <JobNotification
             severity="info"
             icon={<EnergySavingsLeaf fontSize="small" color="success"/>}
         >
-            This job is scheduled Carbon Aware <SwitchableTimeRangeFormatter from={new Date(state.from)} to={new Date(state.to)}/> to minimize carbon impact.
+            This job is scheduled Carbon Aware <SwitchableTimeRangeFormatter from={new Date(carbonAwareAwaitingState.from)} to={new Date(carbonAwareAwaitingState.to)}/> to minimize carbon impact.
         </JobNotification>
     )
 };


### PR DESCRIPTION
When Carbon Aware Job Processing is disabled, the message popping up in the job view is confusing as it looks like the job will still be scheduled using the margin, even though below you can see in the scheduled state that it is disabled and we schedule it using `scheduledAt`.

Now, when a scheduledstate hits the UI, the message will be changed if the config is disabled, based on the reason:

![Screenshot 2025-07-10 at 11 40 58](https://github.com/user-attachments/assets/b3b7ab17-4353-4339-9264-c31fa7fa43be)

As a future improvement, we should be able to access some bg server config specifics to check this instead of looking at the reason. That way we can also improve the message if the job is still pending. 
