### PR TITLE
Improve info/error logging related to critical JobRunr lifecycle

### DIFF
--- a/core/src/main/java/org/jobrunr/server/BackgroundJobServer.java
+++ b/core/src/main/java/org/jobrunr/server/BackgroundJobServer.java
@@ -117,6 +117,11 @@ public class BackgroundJobServer implements BackgroundJobServerMBean {
     }
 
     @Override
+    public String toString() {
+        return String.format("BackgroundJobServer (%s - %s)", configuration.getName(), configuration.getId());
+    }
+
+    @Override
     public void start() {
         start(true);
     }
@@ -139,7 +144,7 @@ public class BackgroundJobServer implements BackgroundJobServerMBean {
             if (isStopped()) throw new IllegalStateException("First start the BackgroundJobServer before pausing");
             if (isPaused()) return;
             stopWorkers();
-            LOGGER.info("Paused job processing");
+            LOGGER.info("{} Paused job processing", this);
             lifecycleChange.succeeded();
         }
     }
@@ -150,7 +155,7 @@ public class BackgroundJobServer implements BackgroundJobServerMBean {
             if (isStopped()) throw new IllegalStateException("First start the BackgroundJobServer before resuming");
             if (isProcessing()) return;
             startWorkers();
-            LOGGER.info("Resumed job processing");
+            LOGGER.info("{} Resumed job processing", this);
             lifecycleChange.succeeded();
         }
     }
@@ -160,12 +165,12 @@ public class BackgroundJobServer implements BackgroundJobServerMBean {
         if (isStopping()) return;
         try (LifecycleChangeLock lifecycleChange = lifecycle.goTo(STOP)) {
             if (isStopped()) return;
-            LOGGER.info("BackgroundJobServer - stopping (may take about {})", configuration.getInterruptJobsAwaitDurationOnStopBackgroundJobServer());
+            LOGGER.info("{} stopping (may take about {})", this, configuration.getInterruptJobsAwaitDurationOnStopBackgroundJobServer());
             isMaster = null;
             stopWorkers();
             stopZooKeepers();
             firstHeartbeat = null;
-            LOGGER.info("BackgroundJobServer and BackgroundJobPerformers stopped");
+            LOGGER.info("{} BackgroundJobServer and BackgroundJobPerformers stopped", this);
             lifecycleChange.succeeded();
         }
     }
@@ -210,13 +215,13 @@ public class BackgroundJobServer implements BackgroundJobServerMBean {
 
         this.isMaster = isMaster;
         if (isMaster != null) {
-            LOGGER.info("JobRunr BackgroundJobServer ({}) using {} and {} BackgroundJobPerformers started successfully", getId(), storageProvider.getStorageProviderInfo().getName(), workDistributionStrategy.getWorkerCount());
+            LOGGER.info("JobRunr {} using {} and {} BackgroundJobPerformers started successfully", this, storageProvider.getStorageProviderInfo().getName(), workDistributionStrategy.getWorkerCount());
             if (isMaster) {
                 startJobZooKeepers();
                 runStartupTasks();
             }
         } else {
-            LOGGER.error("JobRunr BackgroundJobServer failed to start");
+            LOGGER.error("JobRunr {} failed to start", this);
         }
     }
 
@@ -323,7 +328,7 @@ public class BackgroundJobServer implements BackgroundJobServerMBean {
 
     private void stopWorkers() {
         if (jobExecutor == null) return;
-        LOGGER.info("BackgroundJobPerformers - stopping (waiting at most {} for jobs to finish)", configuration.getInterruptJobsAwaitDurationOnStopBackgroundJobServer());
+        LOGGER.info("{} BackgroundJobPerformers stopping (waiting at most {} for jobs to finish)", this, configuration.getInterruptJobsAwaitDurationOnStopBackgroundJobServer());
         jobExecutor.stop(configuration.getInterruptJobsAwaitDurationOnStopBackgroundJobServer());
         this.jobExecutor = null;
     }

--- a/core/src/main/java/org/jobrunr/server/ServerZooKeeper.java
+++ b/core/src/main/java/org/jobrunr/server/ServerZooKeeper.java
@@ -54,7 +54,7 @@ public class ServerZooKeeper implements Runnable {
                 signalBackgroundJobServerAliveAndDoZooKeeping();
             }
         } catch (Exception shouldNotHappen) {
-            LOGGER.error("An unrecoverable error occurred. Shutting server down...", shouldNotHappen);
+            LOGGER.error("An unrecoverable error occurred. Shutting down {}...", backgroundJobServer, shouldNotHappen);
             if (masterId == null) backgroundJobServer.setIsMaster(null);
             new Thread(this::stopServer).start();
         }
@@ -64,7 +64,7 @@ public class ServerZooKeeper implements Runnable {
         try {
             storageProvider.signalBackgroundJobServerStopped(backgroundJobServer.getServerStatus());
         } catch (Exception e) {
-            LOGGER.error("Error when signalling that BackgroundJobServer stopped", e);
+            LOGGER.error("Error when signalling that {} stopped", backgroundJobServer, e);
         } finally {
             masterId = null;
         }
@@ -84,11 +84,11 @@ public class ServerZooKeeper implements Runnable {
             determineIfCurrentBackgroundJobServerIsMaster();
         } catch (ServerTimedOutException e) {
             if (restartAttempts.getAndIncrement() < 3) {
-                LOGGER.error("SEVERE ERROR - Server timed out while it's still alive. Are all servers using NTP and in the same timezone? Are you having long GC cycles? Restart attempt {} out of 3", restartAttempts);
+                LOGGER.error("SEVERE ERROR - {} timed out while it's still alive. Are all servers using NTP and in the same timezone? Are you having long GC cycles? Restart attempt {} out of 3", backgroundJobServer, restartAttempts, e);
                 new Thread(this::resetServer).start();
             } else {
-                LOGGER.error("FATAL - Server restarted 3 times but still times out by other servers. Shutting down.");
-                new Thread(this::stopServer).start();
+                LOGGER.error("FATAL - {} restarted 3 times but still times out by other servers. Shutting down.", backgroundJobServer, e);
+                new Thread(() -> this.stopServer()).start();
             }
         }
     }


### PR DESCRIPTION
When running multiple background job servers, logging is very confusing if something goes wrong (e.g. a server stops/starts/restarts due to a ConcurrentModificationException, ...) because of missing or inconsistent name/ids. 

This tiny 🤏 PR adds a bit of verbosity to the important logger outputs making it easier for users and us to debug what's happening. 