### PR TITLE
move poll interval in minutes for carbon aware to its own config

### DIFF
--- a/core/src/main/java/org/jobrunr/server/BackgroundJobServerConfiguration.java
+++ b/core/src/main/java/org/jobrunr/server/BackgroundJobServerConfiguration.java
@@ -20,7 +20,6 @@ import static org.jobrunr.utils.StringUtils.isNullOrEmpty;
 public class BackgroundJobServerConfiguration {
 
     public static final Duration DEFAULT_POLL_INTERVAL = Duration.ofSeconds(15);
-    public static final Duration DEFAULT_CARBON_AWARE_JOB_PROCESSING_POLL_INTERVAL = Duration.ofMinutes(5);
     public static final int DEFAULT_SERVER_TIMEOUT_POLL_INTERVAL_MULTIPLICAND = 4;
     public static final int DEFAULT_PAGE_REQUEST_SIZE = 1000;
     public static final Duration DEFAULT_DELETE_SUCCEEDED_JOBS_DURATION = Duration.ofHours(36);
@@ -31,7 +30,6 @@ public class BackgroundJobServerConfiguration {
     int orphanedJobsRequestSize = DEFAULT_PAGE_REQUEST_SIZE;
     int succeededJobsRequestSize = DEFAULT_PAGE_REQUEST_SIZE;
     Duration pollInterval = DEFAULT_POLL_INTERVAL;
-    Duration carbonAwareJobProcessingPollInterval = DEFAULT_CARBON_AWARE_JOB_PROCESSING_POLL_INTERVAL;
     int serverTimeoutPollIntervalMultiplicand = DEFAULT_SERVER_TIMEOUT_POLL_INTERVAL_MULTIPLICAND;
     UUID id = UUID.randomUUID();
     String name = getHostName();
@@ -99,29 +97,6 @@ public class BackgroundJobServerConfiguration {
     public BackgroundJobServerConfiguration andPollInterval(Duration pollInterval) {
         this.pollInterval = pollInterval;
         return this;
-    }
-
-    /**
-     * Allows to set the pollInterval for carbon aware job processing on the BackgroundJobServer
-     * This should typically be in minutes and longer than {@link BackgroundJobServerConfiguration#andPollInterval(Duration)} for tasks because of the nature of carbon aware job procesing.
-     *
-     * @param pollInterval the pollInterval duration
-     * @return the same configuration instance which provides a fluent api
-     */
-    public BackgroundJobServerConfiguration andCarbonAwareJobProcessingPollInterval(Duration pollInterval) {
-        this.carbonAwareJobProcessingPollInterval = pollInterval;
-        return this;
-    }
-
-    /**
-     * Allows to set the pollInterval in minutes for carbon aware job processing on the BackgroundJobServer
-     * This can be a much longer interval than {@code pollInterval} for tasks because of the nature of carbon aware job procesing.
-     *
-     * @param minutes the pollInterval duration in minutes
-     * @return the same configuration instance which provides a fluent api
-     */
-    public BackgroundJobServerConfiguration andCarbonAwareJobProcessingPollIntervalInMinutes(int minutes) {
-        return andCarbonAwareJobProcessingPollInterval(Duration.ofMinutes(minutes));
     }
 
     /**

--- a/core/src/main/java/org/jobrunr/server/BackgroundJobServerConfigurationReader.java
+++ b/core/src/main/java/org/jobrunr/server/BackgroundJobServerConfigurationReader.java
@@ -43,10 +43,6 @@ public class BackgroundJobServerConfigurationReader {
         return configuration.pollInterval;
     }
 
-    public Duration getCarbonAwareJobProcessingPollInterval() {
-        return configuration.carbonAwareJobProcessingPollInterval;
-    }
-
     public Integer getServerTimeoutPollIntervalMultiplicand() {
         return configuration.serverTimeoutPollIntervalMultiplicand;
     }

--- a/core/src/main/java/org/jobrunr/server/carbonaware/CarbonAwareJobProcessingConfiguration.java
+++ b/core/src/main/java/org/jobrunr/server/carbonaware/CarbonAwareJobProcessingConfiguration.java
@@ -1,5 +1,7 @@
 package org.jobrunr.server.carbonaware;
 
+import org.jobrunr.server.BackgroundJobServerConfiguration;
+
 import java.time.Duration;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -13,6 +15,7 @@ public class CarbonAwareJobProcessingConfiguration {
     public static final Duration DEFAULT_API_CLIENT_CONNECT_TIMEOUT = Duration.ofSeconds(3);
     public static final Duration DEFAULT_API_CLIENT_READ_TIMEOUT = Duration.ofSeconds(3);
     public static final Integer DEFAULT_API_CLIENT_RETRIES_ON_EXCEPTION = 3;
+    public static final Duration DEFAULT_POLL_INTERVAL = Duration.ofMinutes(5);
 
     boolean enabled = false;
     String carbonIntensityApiUrl = DEFAULT_CARBON_INTENSITY_API_URL;
@@ -23,6 +26,7 @@ public class CarbonAwareJobProcessingConfiguration {
     Integer apiClientRetriesOnException = DEFAULT_API_CLIENT_RETRIES_ON_EXCEPTION;
     Duration apiClientConnectTimeout = DEFAULT_API_CLIENT_CONNECT_TIMEOUT;
     Duration apiClientReadTimeout = DEFAULT_API_CLIENT_READ_TIMEOUT;
+    Duration pollInterval = DEFAULT_POLL_INTERVAL;
 
     private CarbonAwareJobProcessingConfiguration() {
     }
@@ -34,6 +38,29 @@ public class CarbonAwareJobProcessingConfiguration {
      */
     public static CarbonAwareJobProcessingConfiguration usingStandardCarbonAwareJobProcessingConfiguration() {
         return new CarbonAwareJobProcessingConfiguration().andCarbonAwareSchedulingEnabled(true);
+    }
+
+    /**
+     * Allows to set the pollInterval for carbon aware job processing on the BackgroundJobServer
+     * This should typically be in minutes and longer than {@link BackgroundJobServerConfiguration#andPollInterval(Duration)} for tasks because of the nature of carbon aware job procesing.
+     *
+     * @param pollInterval the pollInterval duration
+     * @return the same configuration instance which provides a fluent api
+     */
+    public CarbonAwareJobProcessingConfiguration andPollInterval(Duration pollInterval) {
+        this.pollInterval = pollInterval;
+        return this;
+    }
+
+    /**
+     * Allows to set the pollInterval in minutes for carbon aware job processing on the BackgroundJobServer
+     * This can be a much longer interval than {@code pollInterval} for tasks because of the nature of carbon aware job procesing.
+     *
+     * @param minutes the pollInterval duration in minutes
+     * @return the same configuration instance which provides a fluent api
+     */
+    public CarbonAwareJobProcessingConfiguration andPollIntervalInMinutes(int minutes) {
+        return andPollInterval(Duration.ofMinutes(minutes));
     }
 
     /**

--- a/core/src/main/java/org/jobrunr/server/carbonaware/CarbonAwareJobProcessingConfigurationReader.java
+++ b/core/src/main/java/org/jobrunr/server/carbonaware/CarbonAwareJobProcessingConfigurationReader.java
@@ -38,6 +38,10 @@ public class CarbonAwareJobProcessingConfigurationReader {
         return "/carbon-intensity/forecast";
     }
 
+    public Duration getPollInterval() {
+        return carbonAwareJobProcessingConfiguration.pollInterval;
+    }
+
     URL getCarbonIntensityForecastApiFullPathUrl() throws MalformedURLException {
         return new URL(getCarbonIntensityApiBaseUrl() + getCarbonIntensityForecastQueryString());
     }

--- a/core/src/main/java/org/jobrunr/server/tasks/zookeeper/ProcessCarbonAwareAwaitingJobsTask.java
+++ b/core/src/main/java/org/jobrunr/server/tasks/zookeeper/ProcessCarbonAwareAwaitingJobsTask.java
@@ -64,7 +64,7 @@ public class ProcessCarbonAwareAwaitingJobsTask extends AbstractJobZooKeeperTask
                     this::moveCarbonAwareJobToNextState,
                     amountProcessed -> LOGGER.debug("Moved {} carbon aware jobs to next state", amountProcessed));
 
-            nextRunTaskTime = nextRunTaskTime.plus(backgroundJobServer.getConfiguration().getCarbonAwareJobProcessingPollInterval());
+            nextRunTaskTime = nextRunTaskTime.plus(getCarbonAwareJobProcessingConfiguration(backgroundJobServer).getPollInterval());
         }
     }
 

--- a/core/src/test/java/org/jobrunr/scheduling/BackgroundJobByJobLambdaTest.java
+++ b/core/src/test/java/org/jobrunr/scheduling/BackgroundJobByJobLambdaTest.java
@@ -106,7 +106,6 @@ public class BackgroundJobByJobLambdaTest {
                 .useStorageProvider(storageProvider)
                 .useBackgroundJobServer(usingStandardBackgroundJobServerConfiguration()
                         .andPollInterval(ofMillis(200))
-                        .andCarbonAwareJobProcessingPollInterval(ofMillis(200))
                         .andCarbonAwareJobProcessingConfiguration(carbonAwareWiremock.getCarbonAwareJobProcessingConfigurationForAreaCode("BE")))
                 .initialize();
 

--- a/core/src/test/java/org/jobrunr/server/carbonaware/CarbonAwareApiWireMockExtension.java
+++ b/core/src/test/java/org/jobrunr/server/carbonaware/CarbonAwareApiWireMockExtension.java
@@ -26,6 +26,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static java.lang.String.format;
+import static java.time.Duration.ofMillis;
 import static java.time.ZoneId.systemDefault;
 import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MINUTES;
@@ -62,6 +63,7 @@ public class CarbonAwareApiWireMockExtension implements Extension, BeforeEachCal
     public CarbonAwareJobProcessingConfiguration getCarbonAwareJobProcessingConfigurationForAreaCode(String areaCode) {
         var config = usingStandardCarbonAwareJobProcessingConfiguration()
                 .andApiClientRetriesOnException(1)
+                .andPollInterval(ofMillis(200))
                 .andAreaCode(areaCode);
         Whitebox.setInternalState(config, "carbonIntensityApiUrl", getCarbonIntensityForecastApiRootUrl(carbonIntensityApiBaseUrl));
         return config;

--- a/core/src/test/java/org/jobrunr/server/tasks/AbstractTaskTest.java
+++ b/core/src/test/java/org/jobrunr/server/tasks/AbstractTaskTest.java
@@ -72,8 +72,7 @@ public abstract class AbstractTaskTest {
     protected void setUpTaskDependencies(StorageProvider storageProvider) {
         logAllStateChangesFilter = new LogAllStateChangesFilter();
         BackgroundJobServerConfiguration configuration = usingStandardBackgroundJobServerConfiguration()
-                .andPollIntervalInSeconds(POLL_INTERVAL_IN_SECONDS)
-                .andCarbonAwareJobProcessingPollInterval(Duration.ofSeconds(POLL_INTERVAL_IN_SECONDS));
+                .andPollIntervalInSeconds(POLL_INTERVAL_IN_SECONDS);
         setUpBackgroundJobServerConfiguration(configuration);
         backgroundJobServer = createBackgroundJobServerSpy(storageProvider, configuration);
         backgroundJobServer.setJobFilters(List.of(logAllStateChangesFilter));

--- a/core/src/test/java/org/jobrunr/server/tasks/zookeeper/ProcessRecurringJobsTaskIntegrationTest.java
+++ b/core/src/test/java/org/jobrunr/server/tasks/zookeeper/ProcessRecurringJobsTaskIntegrationTest.java
@@ -71,7 +71,6 @@ public class ProcessRecurringJobsTaskIntegrationTest {
                 .useStorageProvider(storageProvider)
                 .useBackgroundJobServer(usingStandardBackgroundJobServerConfiguration()
                         .andPollInterval(ofMillis(200))
-                        .andCarbonAwareJobProcessingPollInterval(ofMillis(200))
                         .andCarbonAwareJobProcessingConfiguration(carbonAwareWiremock.getCarbonAwareJobProcessingConfigurationForAreaCode("BE")))
                 .initialize();
         this.backgroundJobServer = JobRunr.getBackgroundJobServer();

--- a/core/src/testFixtures/java/org/jobrunr/jobs/carbonaware/CarbonAwareJobProcessingConfigurationAssert.java
+++ b/core/src/testFixtures/java/org/jobrunr/jobs/carbonaware/CarbonAwareJobProcessingConfigurationAssert.java
@@ -63,4 +63,10 @@ public class CarbonAwareJobProcessingConfigurationAssert extends AbstractAssert<
         Assertions.assertThat(actual.getApiClientReadTimeout()).isEqualTo(readTimeout);
         return this;
     }
+
+    public CarbonAwareJobProcessingConfigurationAssert hasPollIntervalInMinutes(int pollIntervalInMinutes) {
+        Assertions.assertThat(actual.getPollInterval()).isEqualTo(Duration.ofMinutes(pollIntervalInMinutes));
+        return this;
+    }
+
 }

--- a/core/src/testFixtures/java/org/jobrunr/server/BackgroundJobServerConfigurationAssert.java
+++ b/core/src/testFixtures/java/org/jobrunr/server/BackgroundJobServerConfigurationAssert.java
@@ -29,11 +29,6 @@ public class BackgroundJobServerConfigurationAssert extends AbstractAssert<Backg
         return this;
     }
 
-    public BackgroundJobServerConfigurationAssert hasCarbonAwareJobProcessingPollIntervalInMinutes(int pollIntervalInMinutes) {
-        Assertions.assertThat(actual.getCarbonAwareJobProcessingPollInterval()).isEqualTo(Duration.ofMinutes(pollIntervalInMinutes));
-        return this;
-    }
-
     public BackgroundJobServerConfigurationAssert hasPollInterval(Duration pollInterval) {
         Assertions.assertThat(actual.getPollInterval()).isEqualTo(pollInterval);
         return this;

--- a/framework-support/jobrunr-micronaut-feature/jobrunr-micronaut/src/main/java/org/jobrunr/micronaut/autoconfigure/JobRunrConfiguration.java
+++ b/framework-support/jobrunr-micronaut-feature/jobrunr-micronaut/src/main/java/org/jobrunr/micronaut/autoconfigure/JobRunrConfiguration.java
@@ -132,11 +132,6 @@ public interface JobRunrConfiguration {
         Optional<Integer> getPollIntervalInSeconds();
 
         /**
-         * Set the carbonAwareJobProcessingPollIntervalInMinutes for the BackgroundJobServer to process carbon aware jobs
-         */
-        Optional<Integer> getCarbonAwareJobProcessingPollIntervalInMinutes();
-
-        /**
          * Set the pollInterval multiplicand used to determine when a BackgroundJobServer has timed out and processing jobs are orphaned.
          */
         Optional<Integer> getServerTimeoutPollIntervalMultiplicand();
@@ -204,6 +199,11 @@ public interface JobRunrConfiguration {
             Optional<Integer> getApiClientConnectTimeoutMs();
 
             Optional<Integer> getApiClientReadTimeoutMs();
+
+            /**
+             * Set the poll interval in minutes for the BackgroundJobServer to process carbon aware jobs
+             */
+            Optional<Integer> PollIntervalInMinutes();
         }
     }
 

--- a/framework-support/jobrunr-micronaut-feature/jobrunr-micronaut/src/main/java/org/jobrunr/micronaut/autoconfigure/JobRunrFactory.java
+++ b/framework-support/jobrunr-micronaut-feature/jobrunr-micronaut/src/main/java/org/jobrunr/micronaut/autoconfigure/JobRunrFactory.java
@@ -72,7 +72,6 @@ public class JobRunrFactory {
 
         configuration.getBackgroundJobServer().getName().ifPresent(backgroundJobServerConfiguration::andName);
         configuration.getBackgroundJobServer().getPollIntervalInSeconds().ifPresent(backgroundJobServerConfiguration::andPollIntervalInSeconds);
-        configuration.getBackgroundJobServer().getCarbonAwareJobProcessingPollIntervalInMinutes().ifPresent(backgroundJobServerConfiguration::andCarbonAwareJobProcessingPollIntervalInMinutes);
         configuration.getBackgroundJobServer().getServerTimeoutPollIntervalMultiplicand().ifPresent(backgroundJobServerConfiguration::andServerTimeoutPollIntervalMultiplicand);
         configuration.getBackgroundJobServer().getDeleteSucceededJobsAfter().ifPresent(backgroundJobServerConfiguration::andDeleteSucceededJobsAfter);
         configuration.getBackgroundJobServer().getPermanentlyDeleteDeletedJobsAfter().ifPresent(backgroundJobServerConfiguration::andPermanentlyDeleteDeletedJobsAfter);
@@ -90,6 +89,7 @@ public class JobRunrFactory {
         configuration.getBackgroundJobServer().getCarbonAwareJobProcessingConfiguration().getExternalIdentifier().ifPresent(carbonAwareJobProcessingConfiguration::andExternalIdentifier);
         configuration.getBackgroundJobServer().getCarbonAwareJobProcessingConfiguration().getApiClientConnectTimeoutMs().ifPresent(connectTimeout -> carbonAwareJobProcessingConfiguration.andApiClientConnectTimeout(Duration.ofMillis(connectTimeout)));
         configuration.getBackgroundJobServer().getCarbonAwareJobProcessingConfiguration().getApiClientReadTimeoutMs().ifPresent(readTimeout -> carbonAwareJobProcessingConfiguration.andApiClientReadTimeout(Duration.ofMillis(readTimeout)));
+        configuration.getBackgroundJobServer().getCarbonAwareJobProcessingConfiguration().PollIntervalInMinutes().ifPresent(carbonAwareJobProcessingConfiguration::andPollIntervalInMinutes);
         backgroundJobServerConfiguration.andCarbonAwareJobProcessingConfiguration(carbonAwareJobProcessingConfiguration);
         return backgroundJobServerConfiguration;
     }

--- a/framework-support/jobrunr-micronaut-feature/jobrunr-micronaut/src/test/java/org/jobrunr/micronaut/autoconfigure/JobRunrFactoryTest.java
+++ b/framework-support/jobrunr-micronaut-feature/jobrunr-micronaut/src/test/java/org/jobrunr/micronaut/autoconfigure/JobRunrFactoryTest.java
@@ -57,6 +57,7 @@ class JobRunrFactoryTest {
     @Property(name = "jobrunr.background-job-server.carbon-aware-job-processing.area-code", value = "PL")
     @Property(name = "jobrunr.background-job-server.carbon-aware-job-processing.api-client-connect-timeout-ms", value = "500")
     @Property(name = "jobrunr.background-job-server.carbon-aware-job-processing.api-client-read-timeout-ms", value = "1000")
+    @Property(name = "jobrunr.background-job-server.carbon-aware-job-processing.poll-interval-in-minutes", value = "15")
     void testCarbonAwareJobProcessingConfiguration() {
         BackgroundJobServer backgroundJobServer = context.getBean(BackgroundJobServer.class);
         CarbonAwareJobProcessingConfigurationReader carbonAwareJobProcessingConfiguration = backgroundJobServer.getConfiguration().getCarbonAwareJobProcessingConfiguration();
@@ -64,7 +65,8 @@ class JobRunrFactoryTest {
         assertThat(carbonAwareJobProcessingConfiguration)
                 .hasAreaCode("PL")
                 .hasApiClientConnectTimeout(Duration.ofMillis(500))
-                .hasApiClientReadTimeout(Duration.ofMillis(1000));
+                .hasApiClientReadTimeout(Duration.ofMillis(1000))
+                .hasPollIntervalInMinutes(15);
     }
 
     @Test
@@ -126,13 +128,11 @@ class JobRunrFactoryTest {
     @Test
     @Property(name = "jobrunr.background-job-server.enabled", value = "true")
     @Property(name = "jobrunr.background-job-server.poll-interval-in-seconds", value = "5")
-    @Property(name = "jobrunr.background-job-server.carbon-aware-job-processing-poll-interval-in-minutes", value = "15")
     @Property(name = "jobrunr.background-job-server.server-timeout-poll-interval-multiplicand", value = "10")
     void backgroundJobServerAutoConfigurationTakesAllPollIntervalPropertiesIntoAccount() {
         BackgroundJobServerConfiguration backgroundJobServerConfiguration = context.getBean(BackgroundJobServerConfiguration.class);
         assertThat(backgroundJobServerConfiguration)
                 .hasPollIntervalInSeconds(5)
-                .hasCarbonAwareJobProcessingPollIntervalInMinutes(15)
                 .hasServerTimeoutPollIntervalMultiplicand(10);
     }
 

--- a/framework-support/jobrunr-quarkus-extension/quarkus-jobrunr/src/main/java/org/jobrunr/quarkus/autoconfigure/JobRunrRuntimeConfiguration.java
+++ b/framework-support/jobrunr-quarkus-extension/quarkus-jobrunr/src/main/java/org/jobrunr/quarkus/autoconfigure/JobRunrRuntimeConfiguration.java
@@ -157,11 +157,6 @@ public interface JobRunrRuntimeConfiguration {
         Optional<Integer> pollIntervalInSeconds();
 
         /**
-         * Set the carbonAwareJobProcessingPollIntervalInMinutes for the BackgroundJobServer to process carbon aware jobs
-         */
-        Optional<Integer> getCarbonAwareJobProcessingPollIntervalInMinutes();
-
-        /**
          * Set the pollInterval multiplicand used to determine when a BackgroundJobServer has timed out and processing jobs are orphaned.
          */
         Optional<Integer> serverTimeoutPollIntervalMultiplicand();
@@ -253,6 +248,11 @@ public interface JobRunrRuntimeConfiguration {
          * Allows to set the read timeout for the carbon api client
          */
         Optional<Integer> apiClientReadTimeoutMs();
+
+        /**
+         * Set the carbon aware poll interval in minutes for the BackgroundJobServer to process carbon aware jobs
+         */
+        Optional<Integer> pollIntervalInMinutes();
     }
 
 

--- a/framework-support/jobrunr-quarkus-extension/quarkus-jobrunr/src/main/java/org/jobrunr/quarkus/autoconfigure/server/JobRunrBackgroundJobServerProducer.java
+++ b/framework-support/jobrunr-quarkus-extension/quarkus-jobrunr/src/main/java/org/jobrunr/quarkus/autoconfigure/server/JobRunrBackgroundJobServerProducer.java
@@ -54,7 +54,6 @@ public class JobRunrBackgroundJobServerProducer {
 
             jobRunrRuntimeConfiguration.backgroundJobServer().name().ifPresent(backgroundJobServerConfiguration::andName);
             jobRunrRuntimeConfiguration.backgroundJobServer().pollIntervalInSeconds().ifPresent(backgroundJobServerConfiguration::andPollIntervalInSeconds);
-            jobRunrRuntimeConfiguration.backgroundJobServer().getCarbonAwareJobProcessingPollIntervalInMinutes().ifPresent(backgroundJobServerConfiguration::andCarbonAwareJobProcessingPollIntervalInMinutes);
             jobRunrRuntimeConfiguration.backgroundJobServer().serverTimeoutPollIntervalMultiplicand().ifPresent(backgroundJobServerConfiguration::andServerTimeoutPollIntervalMultiplicand);
             jobRunrRuntimeConfiguration.backgroundJobServer().deleteSucceededJobsAfter().ifPresent(backgroundJobServerConfiguration::andDeleteSucceededJobsAfter);
             jobRunrRuntimeConfiguration.backgroundJobServer().permanentlyDeleteDeletedJobsAfter().ifPresent(backgroundJobServerConfiguration::andPermanentlyDeleteDeletedJobsAfter);
@@ -72,6 +71,7 @@ public class JobRunrBackgroundJobServerProducer {
             jobRunrRuntimeConfiguration.backgroundJobServer().carbonAwareJobProcessingConfiguration().externalIdentifier().ifPresent(carbonAwareJobProcessingConfiguration::andExternalIdentifier);
             jobRunrRuntimeConfiguration.backgroundJobServer().carbonAwareJobProcessingConfiguration().apiClientConnectTimeoutMs().ifPresent(connectTimeout -> carbonAwareJobProcessingConfiguration.andApiClientConnectTimeout(Duration.ofMillis(connectTimeout)));
             jobRunrRuntimeConfiguration.backgroundJobServer().carbonAwareJobProcessingConfiguration().apiClientReadTimeoutMs().ifPresent(readTimeout -> carbonAwareJobProcessingConfiguration.andApiClientReadTimeout(Duration.ofMillis(readTimeout)));
+            jobRunrRuntimeConfiguration.backgroundJobServer().carbonAwareJobProcessingConfiguration().pollIntervalInMinutes().ifPresent(carbonAwareJobProcessingConfiguration::andPollIntervalInMinutes);
             backgroundJobServerConfiguration.andCarbonAwareJobProcessingConfiguration(carbonAwareJobProcessingConfiguration);
             return backgroundJobServerConfiguration;
         }

--- a/framework-support/jobrunr-quarkus-extension/quarkus-jobrunr/src/test/java/org/jobrunr/quarkus/autoconfigure/server/JobRunrBackgroundJobServerProducerTest.java
+++ b/framework-support/jobrunr-quarkus-extension/quarkus-jobrunr/src/test/java/org/jobrunr/quarkus/autoconfigure/server/JobRunrBackgroundJobServerProducerTest.java
@@ -94,7 +94,6 @@ class JobRunrBackgroundJobServerProducerTest {
         when(backgroundJobServerRunTimeConfiguration.workerCount()).thenReturn(Optional.of(25));
         when(backgroundJobServerRunTimeConfiguration.threadType()).thenReturn(Optional.of(BackgroundJobServerThreadType.PlatformThreads));
         when(backgroundJobServerRunTimeConfiguration.pollIntervalInSeconds()).thenReturn(Optional.of(5));
-        when(backgroundJobServerRunTimeConfiguration.getCarbonAwareJobProcessingPollIntervalInMinutes()).thenReturn(Optional.of(15));
         when(backgroundJobServerRunTimeConfiguration.serverTimeoutPollIntervalMultiplicand()).thenReturn(Optional.of(10));
         when(backgroundJobServerRunTimeConfiguration.scheduledJobsRequestSize()).thenReturn(Optional.of(1));
         when(backgroundJobServerRunTimeConfiguration.orphanedJobsRequestSize()).thenReturn(Optional.of(2));
@@ -109,7 +108,6 @@ class JobRunrBackgroundJobServerProducerTest {
                 .hasName("test")
                 .hasWorkerCount(25)
                 .hasPollIntervalInSeconds(5)
-                .hasCarbonAwareJobProcessingPollIntervalInMinutes(15)
                 .hasServerTimeoutPollIntervalMultiplicand(10)
                 .hasScheduledJobRequestSize(1)
                 .hasOrphanedJobRequestSize(2)
@@ -141,6 +139,7 @@ class JobRunrBackgroundJobServerProducerTest {
         when(carbonAwareJobProcessingRunTimeConfiguration.areaCode()).thenReturn(Optional.of("DE"));
         when(carbonAwareJobProcessingRunTimeConfiguration.apiClientConnectTimeoutMs()).thenReturn(Optional.of(500));
         when(carbonAwareJobProcessingRunTimeConfiguration.apiClientReadTimeoutMs()).thenReturn(Optional.of(1000));
+        when(carbonAwareJobProcessingRunTimeConfiguration.pollIntervalInMinutes()).thenReturn(Optional.of(15));
 
         final BackgroundJobServerConfiguration backgroundJobServerConfiguration = jobRunrBackgroundJobServerProducer.backgroundJobServerConfiguration(jobRunrBackgroundJobServerProducer.backgroundJobServerWorkerPolicy());
         CarbonAwareJobProcessingConfigurationReader carbonAwareJobProcessingConfiguration = new BackgroundJobServerConfigurationReader(backgroundJobServerConfiguration).getCarbonAwareJobProcessingConfiguration();
@@ -148,6 +147,7 @@ class JobRunrBackgroundJobServerProducerTest {
         assertThat(carbonAwareJobProcessingConfiguration)
                 .hasAreaCode("DE")
                 .hasApiClientConnectTimeout(Duration.ofMillis(500))
+                .hasPollIntervalInMinutes(15)
                 .hasApiClientReadTimeout(Duration.ofMillis(1000));
     }
 

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
@@ -113,7 +113,6 @@ public class JobRunrAutoConfiguration {
 
         map.from(backgroundJobServerProperties::getName).whenNonNull().to(backgroundJobServerConfiguration::andName);
         map.from(backgroundJobServerProperties::getPollIntervalInSeconds).to(backgroundJobServerConfiguration::andPollIntervalInSeconds);
-        map.from(backgroundJobServerProperties::getCarbonAwareJobProcessingPollIntervalInMinutes).to(backgroundJobServerConfiguration::andCarbonAwareJobProcessingPollIntervalInMinutes);
         map.from(backgroundJobServerProperties::getServerTimeoutPollIntervalMultiplicand).to(backgroundJobServerConfiguration::andServerTimeoutPollIntervalMultiplicand);
         map.from(backgroundJobServerProperties::getDeleteSucceededJobsAfter).to(backgroundJobServerConfiguration::andDeleteSucceededJobsAfter);
         map.from(backgroundJobServerProperties::getPermanentlyDeleteDeletedJobsAfter).to(backgroundJobServerConfiguration::andPermanentlyDeleteDeletedJobsAfter);
@@ -132,6 +131,7 @@ public class JobRunrAutoConfiguration {
         map.from(carbonAwareJobProcessingProperties::getExternalIdentifier).whenNonNull().to(carbonAwareJobProcessingConfiguration::andExternalIdentifier);
         map.from(carbonAwareJobProcessingProperties::getApiClientConnectTimeout).whenNonNull().to(carbonAwareJobProcessingConfiguration::andApiClientConnectTimeout);
         map.from(carbonAwareJobProcessingProperties::getApiClientReadTimeout).whenNonNull().to(carbonAwareJobProcessingConfiguration::andApiClientReadTimeout);
+        map.from(carbonAwareJobProcessingProperties::getPollIntervalInMinutes).to(carbonAwareJobProcessingConfiguration::andPollIntervalInMinutes);
         backgroundJobServerConfiguration.andCarbonAwareJobProcessingConfiguration(carbonAwareJobProcessingConfiguration);
 
         return backgroundJobServerConfiguration;

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrProperties.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrProperties.java
@@ -257,10 +257,6 @@ public class JobRunrProperties {
          */
         private Integer pollIntervalInSeconds = 15;
         /**
-         * Set the carbonAwareJobProcessingPollIntervalInMinutes for the BackgroundJobServer to see whether pending carbon aware jobs need to be scheduled
-         */
-        private Integer carbonAwareJobProcessingPollIntervalInMinutes = 5;
-        /**
          * Sets the maximum number of carbon aware jobs to update from awaiting to scheduled state per database round-trip.
          */
         private Integer carbonAwaitingJobsRequestSize = 1000;
@@ -354,14 +350,6 @@ public class JobRunrProperties {
 
         public void setPollIntervalInSeconds(Integer pollIntervalInSeconds) {
             this.pollIntervalInSeconds = pollIntervalInSeconds;
-        }
-
-        public Integer getCarbonAwareJobProcessingPollIntervalInMinutes() {
-            return carbonAwareJobProcessingPollIntervalInMinutes;
-        }
-
-        public void setCarbonAwareJobProcessingPollIntervalInMinutes(Integer pollIntervalInMinutes) {
-            this.carbonAwareJobProcessingPollIntervalInMinutes = pollIntervalInMinutes;
         }
 
         public Integer getCarbonAwaitingJobsRequestSize() {
@@ -587,6 +575,11 @@ public class JobRunrProperties {
         @DurationUnit(MILLIS)
         Duration apiClientReadTimeout;
 
+        /**
+         * Set the carbonAwareJobProcessingPollIntervalInMinutes for the BackgroundJobServer to see whether pending carbon aware jobs need to be scheduled
+         */
+        Integer pollIntervalInMinutes = 5;
+
         public boolean isEnabled() {
             return enabled;
         }
@@ -641,6 +634,14 @@ public class JobRunrProperties {
 
         public void setApiClientReadTimeout(Duration apiClientReadTimeout) {
             this.apiClientReadTimeout = apiClientReadTimeout;
+        }
+
+        public Integer getPollIntervalInMinutes() {
+            return pollIntervalInMinutes;
+        }
+
+        public void setPollIntervalInMinutes(Integer pollIntervalInMinutes) {
+            this.pollIntervalInMinutes = pollIntervalInMinutes;
         }
 
     }

--- a/framework-support/jobrunr-spring-boot-3-starter/src/test/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfigurationTest.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/test/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfigurationTest.java
@@ -169,6 +169,7 @@ public class JobRunrAutoConfigurationTest {
                 .withPropertyValues("jobrunr.background-job-server.carbon-aware-job-processing.area-code=FR")
                 .withPropertyValues("jobrunr.background-job-server.carbon-aware-job-processing.api-client-connect-timeout=500")
                 .withPropertyValues("jobrunr.background-job-server.carbon-aware-job-processing.api-client-read-timeout=300")
+                .withPropertyValues("jobrunr.background-job-server.carbon-aware-job-processing.poll-interval-in-minutes=15")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     BackgroundJobServer backgroundJobServer = context.getBean(BackgroundJobServer.class);
                     CarbonAwareJobProcessingConfigurationReader carbonAwareJobProcessingConfiguration = backgroundJobServer.getConfiguration().getCarbonAwareJobProcessingConfiguration();
@@ -176,6 +177,7 @@ public class JobRunrAutoConfigurationTest {
                             .hasEnabled(true)
                             .hasApiClientConnectTimeout(Duration.ofMillis(500))
                             .hasApiClientReadTimeout(Duration.ofMillis(300))
+                            .hasPollIntervalInMinutes(15)
                             .hasAreaCode("FR");
                 });
     }
@@ -221,13 +223,11 @@ public class JobRunrAutoConfigurationTest {
         this.contextRunner
                 .withPropertyValues("jobrunr.background-job-server.enabled=true")
                 .withPropertyValues("jobrunr.background-job-server.poll-interval-in-seconds=5")
-                .withPropertyValues("jobrunr.background-job-server.carbon-aware-job-processing-poll-interval-in-minutes=15")
                 .withPropertyValues("jobrunr.background-job-server.server-timeout-poll-interval-multiplicand=10")
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context).hasSingleBean(BackgroundJobServer.class);
                     assertThat(context.getBean(BackgroundJobServerConfiguration.class))
                             .hasPollIntervalInSeconds(5)
-                            .hasCarbonAwareJobProcessingPollIntervalInMinutes(15)
                             .hasServerTimeoutPollIntervalMultiplicand(10);
                 });
     }


### PR DESCRIPTION
In this PR, we move `carbonAwareJobProcessingPollInterval` created by https://github.com/jobrunr/jobrunr/pull/1352 to the carbon aware job processing configuration itself instead of on the background job server. 