### PR TITLE
fix: disable text select of time scale pain in processing job step

### DIFF
--- a/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/jobs/states/processing-state.js
+++ b/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/jobs/states/processing-state.js
@@ -22,6 +22,7 @@ const Console = styled("div")(() => ({
         textAlign: 'right',
         color: '#3885b7',
         margin: '-0.1em 0',
+        userSelect: 'none',
     },
     '& > dl dd': {
         margin: '-0.2em 0 -0.2em 220px'


### PR DESCRIPTION
under testing.

Current implementation, User cannot copy only log output of "processing job" step, beause it's include time scale text (0 seconds, 3 seconds... for each line).
This PR provide copying only log output by disabling text select of time scale text.