### PR TITLE
deprecate useMicroMeter in favour of useMetrics to sync with JobRunr Pro

### DIFF
--- a/core/src/main/java/org/jobrunr/configuration/JobRunrConfiguration.java
+++ b/core/src/main/java/org/jobrunr/configuration/JobRunrConfiguration.java
@@ -302,12 +302,25 @@ public class JobRunrConfiguration {
     }
 
     /**
-     * Allows integrating MicroMeter metrics into JobRunr
+     * Allows integrating MicroMeter metrics into JobRunr.
+     *
+     * @param microMeterIntegration the JobRunrMicroMeterIntegration
+     * @return the same configuration instance which provides a fluent api
+     * @deprecated please use {@link JobRunrConfiguration#useMetrics(JobRunrMicroMeterIntegration)} instead.
+     */
+    @Deprecated
+    public JobRunrConfiguration useMicroMeter(JobRunrMicroMeterIntegration microMeterIntegration) {
+        this.microMeterIntegration = microMeterIntegration;
+        return this;
+    }
+
+    /**
+     * Allows integrating MicroMeter metrics into JobRunr.
      *
      * @param microMeterIntegration the JobRunrMicroMeterIntegration
      * @return the same configuration instance which provides a fluent api
      */
-    public JobRunrConfiguration useMicroMeter(JobRunrMicroMeterIntegration microMeterIntegration) {
+    public JobRunrConfiguration useMetrics(JobRunrMicroMeterIntegration microMeterIntegration) {
         this.microMeterIntegration = microMeterIntegration;
         return this;
     }


### PR DESCRIPTION
Sync config with JobRunr Pro; `useMicroMeter` should be `useMetrics`

See https://github.com/jobrunr/jobrunr-pro/pull/703