### PR TITLE
add an apiNotification webhook in the notification center

### DIFF
--- a/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/notifications/top-app-bar-notification-center.js
+++ b/core/src/main/resources/org/jobrunr/dashboard/frontend/src/components/notifications/top-app-bar-notification-center.js
@@ -27,6 +27,7 @@ import {subDaysToDate} from "../../utils/helper-functions";
 import {CarbonIntensityApiErrorProblem} from "./carbon-intensity-api-error-problem";
 
 const READ_NOTIFICATIONS_STORAGE_KEY = "readNotifications";
+const WEBHOOK_API_NOTIFICATIONS_CALLED_KEY = "webhookApiNotifications";
 
 const getReadNotifications = () => {
     const storedReadNotifications = localStorage.getItem(READ_NOTIFICATIONS_STORAGE_KEY);
@@ -193,8 +194,6 @@ export const TopAppBarNotificationCenter = React.memo(() => {
     const problemsWithReadStatus = problems.map(p => ({...p, read: isRead(p.id)}));
     const amountOfUnreadNotifications = problemsWithReadStatus.filter(p => !p.read).length;
 
-    const WEBHOOK_API_NOTIFICATIONS_CALLED_KEY = "webhookApiNotificationss"
-
     const callWebhooksForApiNotificationsOnOpen = () => {
         try {
             if(!new URL(apiNotification?.webhook).hostname.endsWith(".jobrunr.io")) return
@@ -202,10 +201,8 @@ export const TopAppBarNotificationCenter = React.memo(() => {
             return
         }
         // Prevent the webhook from being overloaded when closing/opening the notification center
-        const webhooksCalled = localStorage.getItem(WEBHOOK_API_NOTIFICATIONS_CALLED_KEY) ? JSON.parse(localStorage.getItem(WEBHOOK_API_NOTIFICATIONS_CALLED_KEY)) : {}
-        if(webhooksCalled[apiNotification["id"]]) return
-         webhooksCalled[apiNotification["id"]] = "called"
-        localStorage.setItem(WEBHOOK_API_NOTIFICATIONS_CALLED_KEY, JSON.stringify(webhooksCalled))
+        if(localStorage.getItem(WEBHOOK_API_NOTIFICATIONS_CALLED_KEY) === apiNotification["id"]) return
+        localStorage.setItem(WEBHOOK_API_NOTIFICATIONS_CALLED_KEY, apiNotification["id"])
 
         fetch(apiNotification.webhook).catch(() => undefined /* ignored */);
     }


### PR DESCRIPTION
Part of the notification center improvements: https://github.com/jobrunr/website/issues/44

This PR adds the webhook fetch from `apiNotification.webhook` on open that will be returned from the JobRunr API in the future.