### PR TITLE
Fix ReflectionUtils.findMethod()

### DIFF
--- a/core/src/main/java/org/jobrunr/utils/reflection/ReflectionUtils.java
+++ b/core/src/main/java/org/jobrunr/utils/reflection/ReflectionUtils.java
@@ -173,14 +173,14 @@ public class ReflectionUtils {
                 .findFirst();
         if (optionalMethod.isPresent()) {
             return optionalMethod;
+        } else if (!clazz.isInterface() && !Object.class.equals(clazz.getSuperclass())) {
+            return findMethod(clazz.getSuperclass(), predicate);
         } else if (clazz.getInterfaces().length > 0) {
             return Stream.of(clazz.getInterfaces())
                     .map(superInterface -> findMethod(superInterface, predicate))
                     .filter(Optional::isPresent)
                     .findFirst()
                     .orElse(Optional.empty());
-        } else if (!clazz.isInterface() && !Object.class.equals(clazz.getSuperclass())) {
-            return findMethod(clazz.getSuperclass(), predicate);
         } else {
             return Optional.empty();
         }

--- a/core/src/test/java/org/jobrunr/jobs/JobDetailsTest.java
+++ b/core/src/test/java/org/jobrunr/jobs/JobDetailsTest.java
@@ -8,6 +8,7 @@ import org.jobrunr.stubs.TestJobRequest.TestJobRequestHandler;
 import org.jobrunr.stubs.TestService;
 import org.jobrunr.utils.reflection.ReflectionTestClasses.GenericJobRequest;
 import org.jobrunr.utils.reflection.ReflectionTestClasses.Level1JobRequest;
+import org.jobrunr.utils.reflection.ReflectionTestClasses.Level2JobRequest;
 import org.jobrunr.utils.reflection.ReflectionTestClasses.MyAsyncJobRequest;
 import org.junit.jupiter.api.Test;
 
@@ -117,7 +118,13 @@ class JobDetailsTest {
 
     @Test
     void testJobDetailsFromValidJobRequestUsingInheritance() {
-        final Level1JobRequest jobRequest = new Level1JobRequest();
+        final Level1JobRequest<?, ?> jobRequest = new Level2JobRequest();
+        assertThatCode(() -> new JobDetails(jobRequest)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void testJobDetailsFromValidJobRequestUsingMultipleLevelsOfInheritance() {
+        final Level2JobRequest jobRequest = new Level2JobRequest();
         assertThatCode(() -> new JobDetails(jobRequest)).doesNotThrowAnyException();
     }
 

--- a/core/src/test/java/org/jobrunr/utils/reflection/ReflectionTestClasses.java
+++ b/core/src/test/java/org/jobrunr/utils/reflection/ReflectionTestClasses.java
@@ -12,26 +12,31 @@ public class ReflectionTestClasses {
 
     }
 
-    public static class Level0JobRequestHandler<T extends Level0JobRequest> implements JobRequestHandler<T> {
+    public static abstract class Level0JobRequestHandler<T extends Level0JobRequest> implements JobRequestHandler<T> {
         @Override
         public void run(T jobRequest) throws Exception {
             System.out.println(jobRequest);
         }
     }
 
-    public static class Level1JobRequest extends Level0JobRequest {
+    public static abstract class Level1JobRequest
+            <T extends Level1JobRequest<T, H>, H extends Level1JobRequestHandler<T, H>> extends Level0JobRequest {
+    }
+
+    public static abstract class Level1JobRequestHandler
+            <T extends Level1JobRequest<T, H>, H extends Level1JobRequestHandler<T, H>>
+            extends Level0JobRequestHandler<T> implements JobRequestHandler<T> {
+    }
+
+    public static class Level2JobRequest extends Level1JobRequest<Level2JobRequest, Level2JobRequestHandler> {
         @Override
-        public Class<Level1JobRequestHandler> getJobRequestHandler() {
-            return Level1JobRequestHandler.class;
+        public Class<Level2JobRequestHandler> getJobRequestHandler() {
+            return Level2JobRequestHandler.class;
         }
     }
 
-    public static class Level1JobRequestHandler extends Level0JobRequestHandler<Level1JobRequest> {
-        @Override
-        public void run(Level1JobRequest jobRequest) throws Exception {
-            super.run(jobRequest);
-        }
-
+    public static class Level2JobRequestHandler
+            extends Level1JobRequestHandler<Level2JobRequest, Level2JobRequestHandler> {
     }
 
     public static class GenericJobRequest implements JobRequest {

--- a/core/src/test/java/org/jobrunr/utils/reflection/ReflectionUtilsTest.java
+++ b/core/src/test/java/org/jobrunr/utils/reflection/ReflectionUtilsTest.java
@@ -6,7 +6,10 @@ import org.jobrunr.utils.reflection.ReflectionTestClasses.GenericJobRequest;
 import org.jobrunr.utils.reflection.ReflectionTestClasses.GenericJobRequestHandler;
 import org.jobrunr.utils.reflection.ReflectionTestClasses.Level0JobRequest;
 import org.jobrunr.utils.reflection.ReflectionTestClasses.Level0JobRequestHandler;
+import org.jobrunr.utils.reflection.ReflectionTestClasses.Level1JobRequest;
 import org.jobrunr.utils.reflection.ReflectionTestClasses.Level1JobRequestHandler;
+import org.jobrunr.utils.reflection.ReflectionTestClasses.Level2JobRequest;
+import org.jobrunr.utils.reflection.ReflectionTestClasses.Level2JobRequestHandler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -22,7 +25,6 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.jobrunr.utils.reflection.ReflectionTestClasses.Level1JobRequest;
 import static org.jobrunr.utils.reflection.ReflectionUtils.getValueFromFieldOrProperty;
 import static org.jobrunr.utils.reflection.ReflectionUtils.objectContainsFieldOrProperty;
 
@@ -134,6 +136,15 @@ class ReflectionUtilsTest {
 
     @Test
     void testFindMethodOnClassWithMultipleInheritance() {
+        final Optional<Method> level2JobRequestHandlerUsingLevel2JobRequest = ReflectionUtils.findMethod(Level2JobRequestHandler.class, "run", Level2JobRequest.class);
+        assertThat(level2JobRequestHandlerUsingLevel2JobRequest).isPresent();
+
+        final Optional<Method> level2JobRequestHandlerUsingLevel1JobRequest = ReflectionUtils.findMethod(Level2JobRequestHandler.class, "run", Level1JobRequest.class);
+        assertThat(level2JobRequestHandlerUsingLevel1JobRequest).isPresent();
+
+        final Optional<Method> level2JobRequestHandlerUsingLevel0JobRequest = ReflectionUtils.findMethod(Level2JobRequestHandler.class, "run", Level0JobRequest.class);
+        assertThat(level2JobRequestHandlerUsingLevel0JobRequest).isPresent();
+
         final Optional<Method> level1JobRequestHandlerUsingLevel1JobRequest = ReflectionUtils.findMethod(Level1JobRequestHandler.class, "run", Level1JobRequest.class);
         assertThat(level1JobRequestHandlerUsingLevel1JobRequest).isPresent();
 
@@ -142,6 +153,9 @@ class ReflectionUtilsTest {
 
         final Optional<Method> level1JobRequestHandlerUsingJobRequest = ReflectionUtils.findMethod(Level1JobRequestHandler.class, "run", JobRequest.class);
         assertThat(level1JobRequestHandlerUsingJobRequest).isPresent();
+
+        final Optional<Method> level0JobRequestHandlerUsingLevel2JobRequest = ReflectionUtils.findMethod(Level0JobRequestHandler.class, "run", Level2JobRequest.class);
+        assertThat(level0JobRequestHandlerUsingLevel2JobRequest).isPresent();
 
         final Optional<Method> level0JobRequestHandlerUsingLevel1JobRequest = ReflectionUtils.findMethod(Level0JobRequestHandler.class, "run", Level1JobRequest.class);
         assertThat(level0JobRequestHandlerUsingLevel1JobRequest).isPresent();


### PR DESCRIPTION
Fix #1427 (again) by making sure ReflectionUtils navigates the object tree differently. First navigate classes and then only interfaces.

Added extra tests thanks to @cmuchinsky!