### PR TITLE
Add defensive null check in setMethodName() for Kotlin lambda bytecode edge case

### DIFF
--- a/core/src/main/java/org/jobrunr/jobs/details/JobDetailsBuilder.java
+++ b/core/src/main/java/org/jobrunr/jobs/details/JobDetailsBuilder.java
@@ -110,6 +110,14 @@ public abstract class JobDetailsBuilder {
     }
 
     public void setMethodName(String name) {
+        if (name == null) {
+            throw new IllegalStateException(
+                "Could not determine method name from lambda bytecode. " +
+                "This may occur when Kotlin lambdas are compiled with '-Xlambdas=class' instead of " +
+                "the default '-Xlambdas=indy'. Please ensure your build configuration uses the Kotlin " +
+                "compiler's default lambda compilation mode."
+            );
+        }
         if (name.endsWith("$default") && classExists("kotlin.KotlinVersion")) {
             throw new IllegalArgumentException("Unsupported lambda", new UnsupportedOperationException("You are (probably) using Kotlin default parameter values which is not supported by JobRunr."));
         }

--- a/core/src/test/java/org/jobrunr/jobs/details/JobDetailsBuilderTest.java
+++ b/core/src/test/java/org/jobrunr/jobs/details/JobDetailsBuilderTest.java
@@ -50,6 +50,16 @@ class JobDetailsBuilderTest {
                 .hasMessage("The lambda you provided is not valid.");
     }
 
+    @Test
+    void setMethodNameWithNullThrowsHelpfulException() {
+        final JobDetailsBuilder jobDetailsBuilder = getJobDetailsBuilder();
+
+        assertThatThrownBy(() -> jobDetailsBuilder.setMethodName(null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Could not determine method name from lambda bytecode")
+                .hasMessageContaining("-Xlambdas=");
+    }
+
     private JobDetailsBuilder getJobDetailsBuilder() {
         return new JobDetailsBuilder(Arrays.asList("World", null), toFQClassName("org/jobrunr/examples/webapp/api/JobController"), "lambda$simpleJob$4ffb5ff$1") {
 


### PR DESCRIPTION
This PR adds a null check to `JobDetailsBuilder.setMethodName()` that throws a helpful `IllegalStateException` instead of an opaque `NullPointerException`.

### Context

When Kotlin lambdas are compiled with `-Xlambdas=class` (which generates anonymous inner classes) rather than `-Xlambdas=indy` (the Kotlin 2.x default using `invokedynamic`), the bytecode structure differs enough that `KotlinJobDetailsFinder` can't extract the method name. This results in `null` reaching `setMethodName()`, causing:

```
java.lang.NullPointerException: Cannot invoke "String.endsWith(String)" because "name" is null
```

The root cause is in Bazel's `rules_kotlin`, which defaults to `x_lambdas = "class"`. I've opened [bazelbuild/rules_kotlin#1419](https://github.com/bazelbuild/rules_kotlin/pull/1419) to document the workaround there.

### What this PR does

Adds a defensive null check that throws an actionable error message pointing users toward the compiler flag mismatch. The message mentions `-Xlambdas=class` vs `-Xlambdas=indy` specifically so users can search for and apply the fix.

### What this PR doesn't do

This doesn't add support for parsing `-Xlambdas=class` bytecode—that would require more significant changes to `KotlinJobDetailsFinder`. This is a small, low-risk improvement to developer experience.

### Why `IllegalStateException`?

I followed the existing pattern in this method, which throws `IllegalArgumentException` for the `$default` suffix check. `IllegalStateException` felt appropriate here since we're detecting an invalid state (missing method name) rather than an invalid argument value. Happy to change this if you prefer a different exception type.

---

Fixes #1453

I'm happy to iterate on the approach if you have feedback or would prefer a different direction.