### PR TITLE
Fix FailedState deserialization on GraalVM Native Image with Jackson 3

### DIFF
--- a/core/src/main/java/org/jobrunr/jobs/states/FailedState.java
+++ b/core/src/main/java/org/jobrunr/jobs/states/FailedState.java
@@ -17,7 +17,7 @@ public class FailedState extends AbstractJobState {
     private String exceptionCauseType;
     private String exceptionCauseMessage;
     private String stackTrace;
-    private boolean doNotRetry;
+    private Boolean doNotRetry;
 
     protected FailedState() { // for json deserialization
         this(null, null, null, null, null, null, false, Instant.now());

--- a/core/src/test/java/org/jobrunr/jobs/states/FailedStateTest.java
+++ b/core/src/test/java/org/jobrunr/jobs/states/FailedStateTest.java
@@ -1,5 +1,6 @@
 package org.jobrunr.jobs.states;
 
+import org.jobrunr.JobRunrException;
 import org.jobrunr.scheduling.exceptions.JobClassNotFoundException;
 import org.jobrunr.scheduling.exceptions.JobMethodNotFoundException;
 import org.jobrunr.scheduling.exceptions.JobNotFoundException;
@@ -109,6 +110,20 @@ class FailedStateTest {
 
         assertThat(failedState.getException())
                 .isInstanceOf(JobNotFoundException.class);
+    }
+
+    @Test
+    void getExceptionWithoutDoNotRetry() {
+        final FailedState failedState = new FailedState("JobRunr message", new CustomException());
+
+        assertThat(failedState.mustNotRetry()).isFalse();
+    }
+
+    @Test
+    void getExceptionWithDoNotRetry() {
+        final FailedState failedState = new FailedState("JobRunr message", new JobRunrException("Boem", true));
+
+        assertThat(failedState.mustNotRetry()).isTrue();
     }
 
     public static class CustomException extends Exception {


### PR DESCRIPTION
Alternative fix for issue #1493. Move from primitive boolean to boxed Boolean.