### PR TITLE
fix: use non-prefixed version for jobrunr-bom in Gradle module metadata

### DIFF
--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -4,8 +4,6 @@ plugins {
     id 'signing'
 }
 
-version = System.getenv('CI_COMMIT_TAG')?.replace("v", "") ?: "v1.0.0-SNAPSHOT".replace("v", "")
-
 dependencies {
     constraints {
         api 'org.slf4j:slf4j-api:2.0.17'


### PR DESCRIPTION
Fixes - BOM version uses v-prefix (v8.5.0) in Gradle Module Metadata causing issues with Maven repository managers that do not handle v-prefixed Maven versions correctly. 

Fixes #1511