### PR TITLE
Deprecate withJobDetails instead of removing it from test builder classes

### DIFF
--- a/core/src/testFixtures/java/org/jobrunr/jobs/JobTestBuilder.java
+++ b/core/src/testFixtures/java/org/jobrunr/jobs/JobTestBuilder.java
@@ -246,6 +246,16 @@ public class JobTestBuilder {
         return this;
     }
 
+    @Deprecated
+    public JobTestBuilder withJobDetails(JobLambda jobLambda) {
+       return this.withJobLambda(jobLambda);
+    }
+
+    @Deprecated
+    public <S> JobTestBuilder withJobDetails(IocJobLambda<S> jobLambda) {
+        return this.withJobLambda(jobLambda);
+    }
+
     public JobTestBuilder withJobLambda(JobLambda jobLambda) {
         this.jobDetails = new CachingJobDetailsGenerator(new JobDetailsAsmGenerator()).toJobDetails(jobLambda);
         return this;

--- a/core/src/testFixtures/java/org/jobrunr/jobs/RecurringJobTestBuilder.java
+++ b/core/src/testFixtures/java/org/jobrunr/jobs/RecurringJobTestBuilder.java
@@ -64,16 +64,6 @@ public class RecurringJobTestBuilder {
         return this;
     }
 
-    public RecurringJobTestBuilder withJobLambda(JobLambda jobLambda) {
-        this.jobDetails = new JobDetailsAsmGenerator().toJobDetails(jobLambda);
-        return this;
-    }
-
-    public RecurringJobTestBuilder withJobLambda(IocJobLambda jobLambda) {
-        this.jobDetails = new JobDetailsAsmGenerator().toJobDetails(jobLambda);
-        return this;
-    }
-
     public RecurringJobTestBuilder withJobDetails(JobDetailsTestBuilder jobDetailsBuilder) {
         withJobDetails(jobDetailsBuilder.build());
         return this;
@@ -81,6 +71,26 @@ public class RecurringJobTestBuilder {
 
     public RecurringJobTestBuilder withJobDetails(JobDetails jobDetails) {
         this.jobDetails = jobDetails;
+        return this;
+    }
+
+    @Deprecated
+    public RecurringJobTestBuilder withJobDetails(JobLambda jobLambda) {
+        return this.withJobLambda(jobLambda);
+    }
+
+    @Deprecated
+    public RecurringJobTestBuilder withJobDetails(IocJobLambda jobLambda) {
+        return this.withJobLambda(jobLambda);
+    }
+
+    public RecurringJobTestBuilder withJobLambda(JobLambda jobLambda) {
+        this.jobDetails = new JobDetailsAsmGenerator().toJobDetails(jobLambda);
+        return this;
+    }
+
+    public RecurringJobTestBuilder withJobLambda(IocJobLambda jobLambda) {
+        this.jobDetails = new JobDetailsAsmGenerator().toJobDetails(jobLambda);
         return this;
     }
 


### PR DESCRIPTION
Re-adding `withJobDetails` to the `JobTestBuilder` and `RecurringJobTestBuilder` classes and marking them as deprecated instead. This is to avoid any issues for users that might be using them as they are part of the public API.