### PR TITLE
Remove `canOnboardNewWork` from `WorkDistributionStrategy` (unused)

### DIFF
--- a/core/src/main/java/org/jobrunr/server/strategy/BasicWorkDistributionStrategy.java
+++ b/core/src/main/java/org/jobrunr/server/strategy/BasicWorkDistributionStrategy.java
@@ -25,13 +25,6 @@ public class BasicWorkDistributionStrategy implements WorkDistributionStrategy {
     }
 
     @Override
-    public boolean canOnboardNewWork() {
-        final double occupiedWorkerCount = getOccupiedWorkerCount();
-        final boolean canOnboardWork = (occupiedWorkerCount / workerCount) < 0.7;
-        return canOnboardWork;
-    }
-
-    @Override
     public AmountRequest getWorkPageRequest() {
         final int occupiedWorkerCount = getOccupiedWorkerCount();
 

--- a/core/src/main/java/org/jobrunr/server/strategy/WorkDistributionStrategy.java
+++ b/core/src/main/java/org/jobrunr/server/strategy/WorkDistributionStrategy.java
@@ -6,7 +6,5 @@ public interface WorkDistributionStrategy {
 
     int getWorkerCount();
 
-    boolean canOnboardNewWork();
-
     AmountRequest getWorkPageRequest();
 }

--- a/core/src/test/java/org/jobrunr/server/JobStewardTest.java
+++ b/core/src/test/java/org/jobrunr/server/JobStewardTest.java
@@ -119,7 +119,6 @@ class JobStewardTest {
         when(backgroundJobServer.getStorageProvider()).thenReturn(storageProvider);
         when(backgroundJobServer.getWorkDistributionStrategy()).thenReturn(workDistributionStrategy);
         when(backgroundJobServer.getJobFilters()).thenReturn(new JobDefaultFilters());
-        lenient().when(workDistributionStrategy.canOnboardNewWork()).thenReturn(true);
         lenient().when(workDistributionStrategy.getWorkPageRequest()).thenReturn(ascOnUpdatedAt(10));
         lenient().when(backgroundJobServer.isAnnounced()).thenReturn(true);
         lenient().when(backgroundJobServer.isMaster()).thenReturn(true);

--- a/core/src/test/java/org/jobrunr/server/strategy/BasicWorkDistributionStrategyTest.java
+++ b/core/src/test/java/org/jobrunr/server/strategy/BasicWorkDistributionStrategyTest.java
@@ -31,28 +31,28 @@ class BasicWorkDistributionStrategyTest {
     void canOnboardIfWorkQueueSizeIsEmpty() {
         when(jobSteward.getOccupiedWorkerCount()).thenReturn(0);
 
-        assertThat(workDistributionStrategy.canOnboardNewWork()).isTrue();
+        assertThat(workDistributionStrategy.getWorkPageRequest().getLimit()).isEqualTo(100);
     }
 
     @Test
     void canNotOnboardIfWorkQueueIsFull() {
         when(jobSteward.getOccupiedWorkerCount()).thenReturn(100);
 
-        assertThat(workDistributionStrategy.canOnboardNewWork()).isFalse();
+        assertThat(workDistributionStrategy.getWorkPageRequest().getLimit()).isEqualTo(0);
     }
 
     @Test
     void canOnboardIfMoreThan30PercentFreeInWorkQueue() {
         when(jobSteward.getOccupiedWorkerCount()).thenReturn(69);
 
-        assertThat(workDistributionStrategy.canOnboardNewWork()).isTrue();
+        assertThat(workDistributionStrategy.getWorkPageRequest().getLimit()).isEqualTo(31);
     }
 
     @Test
     void canNotOnboardIfLessThan30PercentFreeInWorkQueue() {
         when(jobSteward.getOccupiedWorkerCount()).thenReturn(71);
 
-        assertThat(workDistributionStrategy.canOnboardNewWork()).isFalse();
+        assertThat(workDistributionStrategy.getWorkPageRequest().getLimit()).isEqualTo(29);
     }
 
 }

--- a/core/src/test/java/org/jobrunr/server/strategy/BasicWorkDistributionStrategyTest.java
+++ b/core/src/test/java/org/jobrunr/server/strategy/BasicWorkDistributionStrategyTest.java
@@ -48,11 +48,4 @@ class BasicWorkDistributionStrategyTest {
         assertThat(workDistributionStrategy.getWorkPageRequest().getLimit()).isEqualTo(31);
     }
 
-    @Test
-    void canNotOnboardIfLessThan30PercentFreeInWorkQueue() {
-        when(jobSteward.getOccupiedWorkerCount()).thenReturn(71);
-
-        assertThat(workDistributionStrategy.getWorkPageRequest().getLimit()).isEqualTo(29);
-    }
-
 }


### PR DESCRIPTION
Per discussion https://github.com/jobrunr/jobrunr/discussions/1552.