### PR TITLE
Remove deprecated APIs

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -77,10 +77,10 @@ tasks.named('compileJava', JavaCompile) {
     options.release = 8
 }
 tasks.named('compileTestJava', JavaCompile) {
-    options.release = 11
+    options.release = 17
 }
 tasks.named('compileTestFixturesJava', JavaCompile) {
-    options.release = 11
+    options.release = 17
 }
 tasks.named('compileJava17Java', JavaCompile) {
     options.release = 17

--- a/core/src/main/java/org/jobrunr/configuration/JobRunrConfiguration.java
+++ b/core/src/main/java/org/jobrunr/configuration/JobRunrConfiguration.java
@@ -314,19 +314,6 @@ public class JobRunrConfiguration {
      *
      * @param microMeterIntegration the JobRunrMicroMeterIntegration
      * @return the same configuration instance which provides a fluent api
-     * @deprecated please use {@link JobRunrConfiguration#useMetrics(JobRunrMicroMeterIntegration)} instead.
-     */
-    @Deprecated
-    public JobRunrConfiguration useMicroMeter(JobRunrMicroMeterIntegration microMeterIntegration) {
-        this.microMeterIntegration = microMeterIntegration;
-        return this;
-    }
-
-    /**
-     * Allows integrating MicroMeter metrics into JobRunr.
-     *
-     * @param microMeterIntegration the JobRunrMicroMeterIntegration
-     * @return the same configuration instance which provides a fluent api
      */
     public JobRunrConfiguration useMetrics(JobRunrMicroMeterIntegration microMeterIntegration) {
         this.microMeterIntegration = microMeterIntegration;

--- a/core/src/main/java/org/jobrunr/scheduling/JobBuilder.java
+++ b/core/src/main/java/org/jobrunr/scheduling/JobBuilder.java
@@ -174,31 +174,7 @@ public class JobBuilder {
         this.labels = labels;
         return this;
     }
-
-    /**
-     * Allows to provide the job details by means of Java 8 lambda.
-     *
-     * @param jobLambda the lambda which defines the job
-     * @return the same builder instance that can be given to the {@link JobScheduler#create(JobBuilder)} method
-     * @deprecated use {@link JobBuilder#withJobLambda(JobLambda)} instead
-     */
-    @Deprecated
-    public JobBuilder withDetails(JobLambda jobLambda) {
-        return this.withJobLambda(jobLambda);
-    }
-
-    /**
-     * Allows to provide the job details by means of Java 8 lambda. The IoC container will be used to resolve an actual instance of the requested service.
-     *
-     * @param jobLambda the lambda which defines the job
-     * @return the same builder instance that can be given to the {@link JobScheduler#create(JobBuilder)} method
-     * @deprecated use {@link JobBuilder#withJobLambda(IocJobLambda)} instead
-     */
-    @Deprecated
-    public <S> JobBuilder withDetails(IocJobLambda<S> jobLambda) {
-        return this.withJobLambda(jobLambda);
-    }
-
+    
     /**
      * Allows to provide the job details by means of Java 8 lambda.
      *

--- a/core/src/main/java/org/jobrunr/scheduling/RecurringJobBuilder.java
+++ b/core/src/main/java/org/jobrunr/scheduling/RecurringJobBuilder.java
@@ -118,31 +118,7 @@ public class RecurringJobBuilder {
         this.labels = labels;
         return this;
     }
-
-    /**
-     * Allows to provide the job details by means of Java 8 lambda.
-     *
-     * @param jobLambda the lambda which defines the job
-     * @return the same builder instance that can be given to the {@link JobScheduler#createRecurrently(RecurringJobBuilder)} method
-     * @deprecated use {@link RecurringJobBuilder#withJobLambda(JobLambda)} instead
-     */
-    @Deprecated
-    public RecurringJobBuilder withDetails(JobLambda jobLambda) {
-        return this.withJobLambda(jobLambda);
-    }
-
-    /**
-     * Allows to provide the job details by means of Java 8 lambda. The IoC container will be used to resolve an actual instance of the requested service.
-     *
-     * @param ioCJobLambda the lambda which defines the job
-     * @return the same builder instance that can be given to the {@link JobScheduler#createRecurrently(RecurringJobBuilder)} method
-     * @deprecated use {@link RecurringJobBuilder#withJobLambda(IocJobLambda)} instead
-     */
-    @Deprecated
-    public <S> RecurringJobBuilder withDetails(IocJobLambda<S> ioCJobLambda) {
-        return this.withJobLambda(ioCJobLambda);
-    }
-
+    
     /**
      * Allows to provide the job details by means of Java 8 lambda.
      *

--- a/core/src/test/java/org/jobrunr/utils/mapper/JacksonUsingJSR310JavaTimeModuleJsonMapperTest.java
+++ b/core/src/test/java/org/jobrunr/utils/mapper/JacksonUsingJSR310JavaTimeModuleJsonMapperTest.java
@@ -8,7 +8,6 @@ import org.jobrunr.utils.annotations.Because;
 import org.jobrunr.utils.mapper.jackson.JacksonJsonMapper;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.mockito.internal.util.reflection.Whitebox;
 
 import java.util.Objects;
 
@@ -49,21 +48,27 @@ class JacksonUsingJSR310JavaTimeModuleJsonMapperTest extends AbstractJsonMapperT
                 .hasArgs(someParameter);
     }
 
-    // we cannot use records as the test fixtures are compiled with Java 11 and they are used by other people
-    // for JobRunr 7, bump the testfixtures to Java 17 and test with an actual record
-    // Note for future self: I'm really sorry about this :-s
     @Test
     @Because("https://github.com/jobrunr/jobrunr/issues/779")
-    @Deprecated
-    void testCreatorHasDefaultVisibilityInJacksonObjectMapper() {
-        Object objectMapper = Whitebox.getInternalState(jsonMapper, "objectMapper");
-        Object configOverrides = Whitebox.getInternalState(objectMapper, "_configOverrides");
-        Object visibilityChecker = Whitebox.getInternalState(configOverrides, "_visibilityChecker");
-        assertThat(visibilityChecker.toString()).contains("creator=ANY");
+    void testCanSerializeAndDeserializeRecord() {
+        var someRecord = new SomeRecord(3);
+        Job job = anEnqueuedJob()
+                .withJobLambda(() -> doWorkWithParameter(someRecord))
+                .build();
+
+        String jobAsString = jsonMapper.serialize(job);
+
+        Job deserializedJob = jsonMapper.deserialize(jobAsString, Job.class);
+        assertThat(deserializedJob.getJobDetails())
+                .hasArgs(someRecord);
     }
 
     public void doWorkWithParameter(SomeParameter parameter) {
         System.out.println(parameter);
+    }
+
+    public void doWorkWithParameter(SomeRecord record) {
+        System.out.println(record);
     }
 
     public static class SomeParameter {
@@ -93,4 +98,6 @@ class JacksonUsingJSR310JavaTimeModuleJsonMapperTest extends AbstractJsonMapperT
             return Objects.hash(value);
         }
     }
+
+    public record SomeRecord(int value) {}
 }

--- a/core/src/test/java/org/jobrunr/utils/mapper/JacksonUsingJobRunrTimeModuleJsonMapperTest.java
+++ b/core/src/test/java/org/jobrunr/utils/mapper/JacksonUsingJobRunrTimeModuleJsonMapperTest.java
@@ -7,7 +7,6 @@ import org.jobrunr.jobs.Job;
 import org.jobrunr.utils.annotations.Because;
 import org.jobrunr.utils.mapper.jackson.JacksonJsonMapper;
 import org.junit.jupiter.api.Test;
-import org.mockito.internal.util.reflection.Whitebox;
 
 import java.util.Objects;
 
@@ -30,19 +29,6 @@ public class JacksonUsingJobRunrTimeModuleJsonMapperTest extends AbstractJsonMap
                 .hasCauseInstanceOf(InvalidDefinitionException.class);
     }
 
-    // we cannot use records as the test fixtures are compiled with Java 11 and they are used by other people
-    // for JobRunr 7, bump the testfixtures to Java 17 and test with an actual record
-    // Note for future self: I'm really sorry about this :-s
-    @Test
-    @Because("https://github.com/jobrunr/jobrunr/issues/779")
-    @Deprecated
-    void testCreatorHasDefaultVisibilityInJacksonObjectMapper() {
-        Object objectMapper = Whitebox.getInternalState(jsonMapper, "objectMapper");
-        Object configOverrides = Whitebox.getInternalState(objectMapper, "_configOverrides");
-        Object visibilityChecker = Whitebox.getInternalState(configOverrides, "_visibilityChecker");
-        assertThat(visibilityChecker.toString()).contains("creator=ANY");
-    }
-
     @Test
     @Because("https://github.com/jobrunr/jobrunr/issues/451")
     void testCanDeserializeWithJsonCreator() {
@@ -58,8 +44,27 @@ public class JacksonUsingJobRunrTimeModuleJsonMapperTest extends AbstractJsonMap
                 .hasArgs(someParameter);
     }
 
+    @Test
+    @Because("https://github.com/jobrunr/jobrunr/issues/779")
+    void testCanSerializeAndDeserializeRecord() {
+        var someRecord = new SomeRecord(3);
+        Job job = anEnqueuedJob()
+                .withJobLambda(() -> doWorkWithParameter(someRecord))
+                .build();
+
+        String jobAsString = jsonMapper.serialize(job);
+
+        Job deserializedJob = jsonMapper.deserialize(jobAsString, Job.class);
+        assertThat(deserializedJob.getJobDetails())
+                .hasArgs(someRecord);
+    }
+
     public void doWorkWithParameter(SomeParameter parameter) {
         System.out.println(parameter);
+    }
+
+    public void doWorkWithParameter(SomeRecord record) {
+        System.out.println(record);
     }
 
     public static class SomeParameter {
@@ -89,4 +94,6 @@ public class JacksonUsingJobRunrTimeModuleJsonMapperTest extends AbstractJsonMap
             return Objects.hash(value);
         }
     }
+
+    public record SomeRecord(int value) {}
 }

--- a/core/src/testFixtures/java/org/jobrunr/jobs/JobTestBuilder.java
+++ b/core/src/testFixtures/java/org/jobrunr/jobs/JobTestBuilder.java
@@ -241,16 +241,6 @@ public class JobTestBuilder {
         return this;
     }
 
-    @Deprecated
-    public JobTestBuilder withJobDetails(JobLambda jobLambda) {
-       return this.withJobLambda(jobLambda);
-    }
-
-    @Deprecated
-    public <S> JobTestBuilder withJobDetails(IocJobLambda<S> jobLambda) {
-        return this.withJobLambda(jobLambda);
-    }
-
     public JobTestBuilder withJobLambda(JobLambda jobLambda) {
         this.jobDetails = new CachingJobDetailsGenerator(new JobDetailsAsmGenerator()).toJobDetails(jobLambda);
         return this;

--- a/core/src/testFixtures/java/org/jobrunr/jobs/RecurringJobTestBuilder.java
+++ b/core/src/testFixtures/java/org/jobrunr/jobs/RecurringJobTestBuilder.java
@@ -73,17 +73,7 @@ public class RecurringJobTestBuilder {
         this.jobDetails = jobDetails;
         return this;
     }
-
-    @Deprecated
-    public RecurringJobTestBuilder withJobDetails(JobLambda jobLambda) {
-        return this.withJobLambda(jobLambda);
-    }
-
-    @Deprecated
-    public RecurringJobTestBuilder withJobDetails(IocJobLambda jobLambda) {
-        return this.withJobLambda(jobLambda);
-    }
-
+    
     public RecurringJobTestBuilder withJobLambda(JobLambda jobLambda) {
         this.jobDetails = new JobDetailsAsmGenerator().toJobDetails(jobLambda);
         return this;


### PR DESCRIPTION
**Breaking change**

1. The deprecated `JobRunrConfiguration#useMicroMeter` has been removed, use `JobRunrConfiguration#useMetrics` instead
2. The deprecated `JobBuilder#withDetails` has been removed, use `JobBuilder#withJobLambda` instead
3. The deprecated `RecurringJobBuilder#withDetails` has been removed, use `RecurringJobBuilder#withJobLambda` instead
4. JobRunr test fixtures now require JDK 17 or higher