### PR TITLE
Prevent time-to-check to time-to-use race condition in DatabaseCreator

### DIFF
--- a/core/src/main/java/org/jobrunr/storage/sql/common/DatabaseCreator.java
+++ b/core/src/main/java/org/jobrunr/storage/sql/common/DatabaseCreator.java
@@ -118,11 +118,7 @@ public class DatabaseCreator {
         Set<String> appliedMigrations = isMigrationsTableMissing()
                 ? Collections.emptySet()
                 : loadAppliedMigrations();
-        List<SqlMigration> migrationsToRun = getMigrations()
-                .filter(migration -> migration.getFileName().endsWith(".sql"))
-                .sorted(comparing(SqlMigration::getFileName))
-                .filter(migration -> !appliedMigrations.contains(migration.getFileName()))
-                .collect(toList());
+        List<SqlMigration> migrationsToRun = getMigrationsToRun(appliedMigrations).collect(toList());
         runMigrations(migrationsToRun);
     }
 
@@ -174,7 +170,7 @@ public class DatabaseCreator {
         return databaseMigrationsProvider.getMigrations();
     }
 
-    private void runMigrations(List<SqlMigration> migrationsToRun) {
+    protected void runMigrations(List<SqlMigration> migrationsToRun) {
         if (migrationsToRun.isEmpty()) {
             LOGGER.debug("No migrations to run.");
             migrationsTableLocker.waitUntilMigrationsAreDone();
@@ -187,7 +183,9 @@ public class DatabaseCreator {
 
         if (migrationsTableLocker.lockMigrationsTable()) {
             try {
-                migrationsToRun.forEach(this::runMigration);
+                // why: recomputed to prevent time-of-check to time-of-use race
+                Set<String> appliedMigrations = loadAppliedMigrations();
+                getMigrationsToRun(appliedMigrations).forEach(this::runMigration);
             } finally {
                 migrationsTableLocker.removeMigrationsTableLock();
             }
@@ -269,6 +267,13 @@ public class DatabaseCreator {
             LOGGER.debug("Error loading applied migrations", sqlException);
             throw new StorageException(sqlException);
         }
+    }
+
+    private Stream<SqlMigration> getMigrationsToRun(Set<String> appliedMigrations) {
+        return getMigrations()
+                .filter(migration -> migration.getFileName().endsWith(".sql"))
+                .sorted(comparing(SqlMigration::getFileName))
+                .filter(migration -> !appliedMigrations.contains(migration.getFileName()));
     }
 
     private boolean isCreateMigrationsTableMigration(SqlMigration migration) {

--- a/core/src/test/java/org/jobrunr/storage/sql/common/DatabaseCreatorTablePrefixTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/common/DatabaseCreatorTablePrefixTest.java
@@ -125,7 +125,7 @@ class DatabaseCreatorTablePrefixTest {
         assertThatCode(databaseCreator::runMigrations).isInstanceOf(JobRunrException.class);
 
         LoggerAssert.assertThat(loggerDbCreator)
-                .hasWarningMessageContaining("Error running statement: CREATE TABLE SOME_SCHEMA.SOME_PREFIX_jobrunr_migrations");
+                .hasWarningMessageContaining("Error running statement: CREATE TABLE SOME_SCHEMA.SOME_PREFIX_jobrunr_migrations", 2);
     }
 
     @NotNull

--- a/core/src/test/java/org/jobrunr/storage/sql/common/DatabaseCreatorTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/common/DatabaseCreatorTest.java
@@ -23,12 +23,15 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static ch.qos.logback.LoggerAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -201,6 +204,36 @@ class DatabaseCreatorTest {
                 .hasDebugMessageContaining("Successfully locked the migrations table.", 1)
                 .hasDebugMessageContaining("The lock has been removed from migrations table.", 1)
                 .hasDebugMessageContaining("No migrations to run.", 1);
+    }
+
+    @Test
+    void staleMigrationsAreNotRunWhenLockIsAcquiredAfterAnotherDatabaseCreatorAlreadyFinished() throws InterruptedException {
+        final JdbcDataSource dataSource = createH2DataSource("jdbc:h2:mem:/test-stale-migrations;DB_CLOSE_DELAY=-1");
+        final DatabaseCreator databaseCreator1 = new DatabaseCreator(dataSource, H2StorageProvider.class);
+        final DatabaseCreator databaseCreator2 = Mockito.spy(new DatabaseCreator(dataSource, H2StorageProvider.class));
+
+        final CountDownLatch creator2TookItsSnapshot = new CountDownLatch(1);
+        final CountDownLatch creator1IsDone = new CountDownLatch(1);
+
+        // pause creator2 between taking its appliedMigrations snapshot and acquiring the lock
+        doAnswer(invocation -> {
+            Object migrations = invocation.callRealMethod();
+            creator2TookItsSnapshot.countDown();
+            var ignored = creator1IsDone.await(30, TimeUnit.SECONDS);
+            return migrations;
+        }).when(databaseCreator2).getMigrations();
+
+        Thread t2 = new Thread(databaseCreator2::runMigrations);
+        t2.start();
+        var ignored = creator2TookItsSnapshot.await(10, TimeUnit.SECONDS);
+
+        // creator1 locks, runs all migrations and removes the lock while creator2 is paused
+        databaseCreator1.runMigrations();
+        creator1IsDone.countDown();
+        t2.join();
+
+        verify(databaseCreator2).runMigrations(argThat(migrations -> !migrations.isEmpty()));
+        verify(databaseCreator2, never()).runMigration(argThat(migration -> !migration.getFileName().startsWith("v000__")));
     }
 
     private JdbcDataSource createH2DataSource(String url) {

--- a/core/src/test/java/org/jobrunr/storage/sql/common/DefaultSqlStorageProviderTest.java
+++ b/core/src/test/java/org/jobrunr/storage/sql/common/DefaultSqlStorageProviderTest.java
@@ -27,6 +27,7 @@ import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.jobrunr.jobs.JobTestBuilder.anEnqueuedJob;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -61,6 +62,7 @@ class DefaultSqlStorageProviderTest {
         when(databaseMetaData.getTables(null, null, "%", null)).thenReturn(resultSet);
         when(preparedStatement.executeUpdate()).thenReturn(1);
         lenient().when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        lenient().when(statement.executeQuery(any())).thenReturn(resultSet);
 
         jobStorageProvider = new DefaultSqlStorageProvider(datasource, new AnsiDialect(), DatabaseOptions.CREATE.CREATE);
         jobStorageProvider.setJobMapper(new JobMapper(new JacksonJsonMapper()));

--- a/core/src/testFixtures/java/ch/qos/logback/LoggerAssert.java
+++ b/core/src/testFixtures/java/ch/qos/logback/LoggerAssert.java
@@ -149,8 +149,13 @@ public class LoggerAssert extends AbstractAssert<LoggerAssert, ListAppender<ILog
     }
 
     public LoggerAssert hasWarningMessageContaining(String message) {
-        return hasWarningMessageContaining(message, 1, emptyMap());
+        return hasWarningMessageContaining(message, 1);
     }
+
+    public LoggerAssert hasWarningMessageContaining(String message, int times) {
+        return hasWarningMessageContaining(message, times, emptyMap());
+    }
+
 
     public LoggerAssert hasWarningMessageContaining(String message, Map<String, String> mdcData) {
         return hasWarningMessageContaining(message, 1, mdcData);


### PR DESCRIPTION
Prevents a time-to-check to time-to-use race condition by recomputing the list of migrations to run after locking the migrations table.

An alternative approach would be to always lock the migrations table first but this carries more risk: in case of an exception the lock needs to be manually removed. Also most deployments have no migrations to run, in which case they don't recompute the migrations to apply.

Fixes #1519