### PR TITLE
Make job retention configuration a global configuration

### DIFF
--- a/core/src/main/java/org/jobrunr/configuration/JobConfiguration.java
+++ b/core/src/main/java/org/jobrunr/configuration/JobConfiguration.java
@@ -1,0 +1,29 @@
+package org.jobrunr.configuration;
+
+/**
+ * This class allows configuring global job settings.
+ */
+public class JobConfiguration {
+    JobRetentionConfiguration jobRetentionConfiguration;
+
+    /**
+     * This returns the default configuration applied to jobs globally.
+     *
+     * @return the default Job configuration
+     */
+    public static JobConfiguration usingStandardJobConfiguration() {
+        return new JobConfiguration();
+    }
+
+    /**
+     * Configures how long jobs are kept in storage after they reach a terminal state.
+     *
+     * @param jobRetentionConfiguration the job retention configuration to use
+     * @return the same configuration instance which provides a fluent api
+     * @see JobRetentionConfiguration
+     */
+    public JobConfiguration andJobRetention(JobRetentionConfiguration jobRetentionConfiguration) {
+        this.jobRetentionConfiguration = jobRetentionConfiguration;
+        return this;
+    }
+}

--- a/core/src/main/java/org/jobrunr/configuration/JobRetentionConfiguration.java
+++ b/core/src/main/java/org/jobrunr/configuration/JobRetentionConfiguration.java
@@ -1,0 +1,56 @@
+package org.jobrunr.configuration;
+
+import org.jobrunr.jobs.states.StateName;
+
+import java.time.Duration;
+import java.util.Objects;
+
+public class JobRetentionConfiguration {
+
+    public static final Duration DEFAULT_DELETE_SUCCEEDED_JOBS_DURATION = Duration.ofHours(36);
+    public static final Duration DEFAULT_PERMANENTLY_DELETE_JOBS_DURATION = Duration.ofHours(72);
+
+    private final Duration deleteSucceededJobsAfter;
+    private final Duration permanentlyDeleteDeletedJobsAfter;
+
+    /**
+     * Creates a {@code JobRetentionConfiguration} with the default retention durations.
+     * <p>
+     * Succeeded jobs are moved to {@link StateName#DELETED} after {@link #DEFAULT_DELETE_SUCCEEDED_JOBS_DURATION},
+     * and jobs in the {@link StateName#DELETED} state are permanently removed from storage after {@link #DEFAULT_PERMANENTLY_DELETE_JOBS_DURATION}.
+     *
+     * @see #JobRetentionConfiguration(Duration, Duration)
+     */
+    public JobRetentionConfiguration() {
+        this(DEFAULT_DELETE_SUCCEEDED_JOBS_DURATION, DEFAULT_PERMANENTLY_DELETE_JOBS_DURATION);
+    }
+
+    /**
+     * Creates a {@code JobRetentionConfiguration} with the given retention durations.
+     * <p>
+     * Succeeded jobs are first moved to {@link StateName#DELETED}; they are only removed from
+     * storage once they have been in that state for {@code permanentlyDeleteDeletedJobsAfter}.
+     * Each duration is measured from the moment the job entered its current state.
+     *
+     * @param deleteSucceededJobsAfter          how long a succeeded job is retained before it is
+     *                                          moved to {@link StateName#DELETED}; must not be {@code null}
+     * @param permanentlyDeleteDeletedJobsAfter how long a job stays in {@link StateName#DELETED} before it
+     *                                          is permanently removed from storage; must not be {@code null}
+     * @throws NullPointerException if {@code deleteSucceededJobsAfter} or
+     *                              {@code permanentlyDeleteDeletedJobsAfter} is {@code null}
+     */
+    public JobRetentionConfiguration(Duration deleteSucceededJobsAfter, Duration permanentlyDeleteDeletedJobsAfter) {
+        Objects.requireNonNull(deleteSucceededJobsAfter, "deleteSucceededJobsAfter must not be null");
+        Objects.requireNonNull(permanentlyDeleteDeletedJobsAfter, "permanentlyDeleteDeletedJobsAfter must not be null");
+        this.deleteSucceededJobsAfter = deleteSucceededJobsAfter;
+        this.permanentlyDeleteDeletedJobsAfter = permanentlyDeleteDeletedJobsAfter;
+    }
+
+    public Duration getDeleteSucceededJobsAfter() {
+        return deleteSucceededJobsAfter;
+    }
+
+    public Duration getPermanentlyDeleteDeletedJobsAfter() {
+        return permanentlyDeleteDeletedJobsAfter;
+    }
+}

--- a/core/src/main/java/org/jobrunr/configuration/JobRunrConfiguration.java
+++ b/core/src/main/java/org/jobrunr/configuration/JobRunrConfiguration.java
@@ -105,7 +105,7 @@ public class JobRunrConfiguration {
     /**
      * Configures how long jobs are kept in storage after they reach a terminal state.
      *
-     * @param jobRetentionConfiguration the job retention configuration to use, must not be {@code null}
+     * @param jobRetentionConfiguration the job retention configuration to use
      * @return the same configuration instance which provides a fluent api
      * @see JobRetentionConfiguration
      */

--- a/core/src/main/java/org/jobrunr/configuration/JobRunrConfiguration.java
+++ b/core/src/main/java/org/jobrunr/configuration/JobRunrConfiguration.java
@@ -42,6 +42,7 @@ public class JobRunrConfiguration {
     JobRunrJMXExtensions jmxExtension;
     JobRunrMicroMeterIntegration microMeterIntegration;
 
+    private JobRetentionConfiguration jobRetentionConfiguration;
     private BackgroundJobServerConfiguration backgroundJobServerConfiguration;
     private boolean startBackgroundJobServerOnInitialization;
     private JobRunrDashboardWebServerConfiguration dashboardWebServerConfiguration;
@@ -98,6 +99,18 @@ public class JobRunrConfiguration {
      */
     public JobRunrConfiguration withJobFilter(JobFilter... jobFilters) {
         this.jobFilters.addAll(Arrays.asList(jobFilters));
+        return this;
+    }
+
+    /**
+     * Configures how long jobs are kept in storage after they reach a terminal state.
+     *
+     * @param jobRetentionConfiguration the job retention configuration to use, must not be {@code null}
+     * @return the same configuration instance which provides a fluent api
+     * @see JobRetentionConfiguration
+     */
+    public JobRunrConfiguration useJobRetention(JobRetentionConfiguration jobRetentionConfiguration) {
+        this.jobRetentionConfiguration = jobRetentionConfiguration;
         return this;
     }
 
@@ -369,6 +382,11 @@ public class JobRunrConfiguration {
 
     private void initializeBackgroundJobServer() {
         if (backgroundJobServerConfiguration != null) {
+            if (jobRetentionConfiguration != null) {
+                backgroundJobServerConfiguration
+                        .andDeleteSucceededJobsAfter(jobRetentionConfiguration.getDeleteSucceededJobsAfter())
+                        .andPermanentlyDeleteDeletedJobsAfter(jobRetentionConfiguration.getPermanentlyDeleteDeletedJobsAfter());
+            }
             this.backgroundJobServer = new BackgroundJobServer(storageProvider, jsonMapper, jobActivator, backgroundJobServerConfiguration);
             this.backgroundJobServer.setJobFilters(jobFilters);
             if (startBackgroundJobServerOnInitialization) this.backgroundJobServer.start();

--- a/core/src/main/java/org/jobrunr/configuration/JobRunrConfiguration.java
+++ b/core/src/main/java/org/jobrunr/configuration/JobRunrConfiguration.java
@@ -42,7 +42,7 @@ public class JobRunrConfiguration {
     JobRunrJMXExtensions jmxExtension;
     JobRunrMicroMeterIntegration microMeterIntegration;
 
-    private JobRetentionConfiguration jobRetentionConfiguration;
+    private JobConfiguration jobConfiguration;
     private BackgroundJobServerConfiguration backgroundJobServerConfiguration;
     private boolean startBackgroundJobServerOnInitialization;
     private JobRunrDashboardWebServerConfiguration dashboardWebServerConfiguration;
@@ -55,6 +55,7 @@ public class JobRunrConfiguration {
         this.jobMapper = this.jsonMapper == null ? null : new JobMapper(jsonMapper);
         this.jobDetailsGenerator = new CachingJobDetailsGenerator();
         this.jobFilters = new ArrayList<>();
+        this.jobConfiguration = new JobConfiguration();
     }
 
     /**
@@ -103,14 +104,17 @@ public class JobRunrConfiguration {
     }
 
     /**
-     * Configures how long jobs are kept in storage after they reach a terminal state.
+     * Configures global job settings.
+     * <p>
+     * These settings apply to all jobs managed by JobRunr, such as how long completed,
+     * failed, or deleted jobs are retained after reaching a terminal state.
      *
-     * @param jobRetentionConfiguration the job retention configuration to use
-     * @return the same configuration instance which provides a fluent api
-     * @see JobRetentionConfiguration
+     * @param jobConfiguration the global job configuration
+     * @return this configuration instance for method chaining
+     * @see JobConfiguration#usingStandardJobConfiguration()
      */
-    public JobRunrConfiguration useJobRetention(JobRetentionConfiguration jobRetentionConfiguration) {
-        this.jobRetentionConfiguration = jobRetentionConfiguration;
+    public JobRunrConfiguration useJobConfiguration(JobConfiguration jobConfiguration) {
+        this.jobConfiguration = jobConfiguration;
         return this;
     }
 
@@ -382,7 +386,8 @@ public class JobRunrConfiguration {
 
     private void initializeBackgroundJobServer() {
         if (backgroundJobServerConfiguration != null) {
-            if (jobRetentionConfiguration != null) {
+            if (jobConfiguration.jobRetentionConfiguration != null) {
+                JobRetentionConfiguration jobRetentionConfiguration = jobConfiguration.jobRetentionConfiguration;
                 backgroundJobServerConfiguration
                         .andDeleteSucceededJobsAfter(jobRetentionConfiguration.getDeleteSucceededJobsAfter())
                         .andPermanentlyDeleteDeletedJobsAfter(jobRetentionConfiguration.getPermanentlyDeleteDeletedJobsAfter());

--- a/core/src/main/java/org/jobrunr/server/BackgroundJobServerConfiguration.java
+++ b/core/src/main/java/org/jobrunr/server/BackgroundJobServerConfiguration.java
@@ -1,5 +1,6 @@
 package org.jobrunr.server;
 
+import org.jobrunr.configuration.JobRetentionConfiguration;
 import org.jobrunr.server.carbonaware.CarbonAwareJobProcessingConfiguration;
 import org.jobrunr.server.configuration.BackgroundJobServerWorkerPolicy;
 import org.jobrunr.server.configuration.ConcurrentJobModificationPolicy;
@@ -22,8 +23,6 @@ public class BackgroundJobServerConfiguration {
     public static final Duration DEFAULT_POLL_INTERVAL = Duration.ofSeconds(15);
     public static final int DEFAULT_SERVER_TIMEOUT_POLL_INTERVAL_MULTIPLICAND = 4;
     public static final int DEFAULT_PAGE_REQUEST_SIZE = 1000;
-    public static final Duration DEFAULT_DELETE_SUCCEEDED_JOBS_DURATION = Duration.ofHours(36);
-    public static final Duration DEFAULT_PERMANENTLY_DELETE_JOBS_DURATION = Duration.ofHours(72);
     public static final Duration DEFAULT_INTERRUPT_JOBS_AWAIT_DURATION_ON_STOP_BACKGROUND_JOB_SERVER = Duration.ofSeconds(10);
     int carbonAwareAwaitingJobsRequestSize = DEFAULT_PAGE_REQUEST_SIZE;
     int scheduledJobsRequestSize = DEFAULT_PAGE_REQUEST_SIZE;
@@ -33,8 +32,8 @@ public class BackgroundJobServerConfiguration {
     int serverTimeoutPollIntervalMultiplicand = DEFAULT_SERVER_TIMEOUT_POLL_INTERVAL_MULTIPLICAND;
     UUID id = UUID.randomUUID();
     String name = getHostName();
-    Duration deleteSucceededJobsAfter = DEFAULT_DELETE_SUCCEEDED_JOBS_DURATION;
-    Duration permanentlyDeleteDeletedJobsAfter = DEFAULT_PERMANENTLY_DELETE_JOBS_DURATION;
+    Duration deleteSucceededJobsAfter = JobRetentionConfiguration.DEFAULT_DELETE_SUCCEEDED_JOBS_DURATION;
+    Duration permanentlyDeleteDeletedJobsAfter = JobRetentionConfiguration.DEFAULT_PERMANENTLY_DELETE_JOBS_DURATION;
     Duration interruptJobsAwaitDurationOnStopBackgroundJobServer = DEFAULT_INTERRUPT_JOBS_AWAIT_DURATION_ON_STOP_BACKGROUND_JOB_SERVER;
     BackgroundJobServerWorkerPolicy backgroundJobServerWorkerPolicy = new DefaultBackgroundJobServerWorkerPolicy();
     ConcurrentJobModificationPolicy concurrentJobModificationPolicy = new DefaultConcurrentJobModificationPolicy();
@@ -186,7 +185,9 @@ public class BackgroundJobServerConfiguration {
      *
      * @param duration the duration to wait before deleting successful jobs
      * @return the same configuration instance which provides a fluent api
+     * @deprecated use {@link org.jobrunr.configuration.JobRunrConfiguration#useJobRetention(JobRetentionConfiguration)} to set this duration or provide it via app properties.
      */
+    @Deprecated
     public BackgroundJobServerConfiguration andDeleteSucceededJobsAfter(Duration duration) {
         this.deleteSucceededJobsAfter = duration;
         return this;
@@ -197,7 +198,9 @@ public class BackgroundJobServerConfiguration {
      *
      * @param duration the duration to wait before permanently deleting successful jobs
      * @return the same configuration instance which provides a fluent api
+     * @deprecated use {@link org.jobrunr.configuration.JobRunrConfiguration#useJobRetention(JobRetentionConfiguration)} to set this duration or provide it via app properties.
      */
+    @Deprecated
     public BackgroundJobServerConfiguration andPermanentlyDeleteDeletedJobsAfter(Duration duration) {
         this.permanentlyDeleteDeletedJobsAfter = duration;
         return this;

--- a/core/src/main/java/org/jobrunr/server/BackgroundJobServerConfiguration.java
+++ b/core/src/main/java/org/jobrunr/server/BackgroundJobServerConfiguration.java
@@ -19,6 +19,10 @@ import static org.jobrunr.utils.StringUtils.isNullOrEmpty;
  * This class allows to configure the BackgroundJobServer
  */
 public class BackgroundJobServerConfiguration {
+    @Deprecated
+    public static final Duration DEFAULT_DELETE_SUCCEEDED_JOBS_DURATION = JobRetentionConfiguration.DEFAULT_DELETE_SUCCEEDED_JOBS_DURATION;
+    @Deprecated
+    public static final Duration DEFAULT_PERMANENTLY_DELETE_JOBS_DURATION = JobRetentionConfiguration.DEFAULT_PERMANENTLY_DELETE_JOBS_DURATION;
 
     public static final Duration DEFAULT_POLL_INTERVAL = Duration.ofSeconds(15);
     public static final int DEFAULT_SERVER_TIMEOUT_POLL_INTERVAL_MULTIPLICAND = 4;

--- a/core/src/main/java/org/jobrunr/server/BackgroundJobServerConfiguration.java
+++ b/core/src/main/java/org/jobrunr/server/BackgroundJobServerConfiguration.java
@@ -1,5 +1,6 @@
 package org.jobrunr.server;
 
+import org.jobrunr.configuration.JobConfiguration;
 import org.jobrunr.configuration.JobRetentionConfiguration;
 import org.jobrunr.server.carbonaware.CarbonAwareJobProcessingConfiguration;
 import org.jobrunr.server.configuration.BackgroundJobServerWorkerPolicy;
@@ -50,7 +51,7 @@ public class BackgroundJobServerConfiguration {
     /**
      * This returns the default configuration with the BackgroundJobServer with a poll interval of 15 seconds and a worker count based on the CPU
      *
-     * @return the default JobRunrDashboard configuration
+     * @return the default BackgroundJobServer configuration
      */
     public static BackgroundJobServerConfiguration usingStandardBackgroundJobServerConfiguration() {
         return new BackgroundJobServerConfiguration();
@@ -189,7 +190,7 @@ public class BackgroundJobServerConfiguration {
      *
      * @param duration the duration to wait before deleting successful jobs
      * @return the same configuration instance which provides a fluent api
-     * @deprecated use {@link org.jobrunr.configuration.JobRunrConfiguration#useJobRetention(JobRetentionConfiguration)} to set this duration or provide it via app properties.
+     * @deprecated use {@link org.jobrunr.configuration.JobRunrConfiguration#useJobConfiguration} to set this duration or provide it via app properties.
      */
     @Deprecated
     public BackgroundJobServerConfiguration andDeleteSucceededJobsAfter(Duration duration) {
@@ -202,7 +203,7 @@ public class BackgroundJobServerConfiguration {
      *
      * @param duration the duration to wait before permanently deleting successful jobs
      * @return the same configuration instance which provides a fluent api
-     * @deprecated use {@link org.jobrunr.configuration.JobRunrConfiguration#useJobRetention(JobRetentionConfiguration)} to set this duration or provide it via app properties.
+     * @deprecated use {@link org.jobrunr.configuration.JobRunrConfiguration#useJobConfiguration(JobConfiguration)} to set this duration or provide it via app properties.
      */
     @Deprecated
     public BackgroundJobServerConfiguration andPermanentlyDeleteDeletedJobsAfter(Duration duration) {

--- a/core/src/main/java/org/jobrunr/server/tasks/zookeeper/ProcessCarbonAwareAwaitingJobsTask.java
+++ b/core/src/main/java/org/jobrunr/server/tasks/zookeeper/ProcessCarbonAwareAwaitingJobsTask.java
@@ -183,8 +183,7 @@ public class ProcessCarbonAwareAwaitingJobsTask extends AbstractJobZooKeeperTask
     }
 
     private void deleteOldUnnecessaryForecasts(List<JobRunrMetadata> allForecasts) {
-        Duration jobCompletelyDeletedAfter = backgroundJobServer.getConfiguration().getDeleteSucceededJobsAfter().plus(backgroundJobServer.getConfiguration().getPermanentlyDeleteDeletedJobsAfter());
-        String deleteForecastAfter = now().minus(jobCompletelyDeletedAfter).atZone(ZoneOffset.UTC).toLocalDate().toString();
+        String deleteForecastAfter = now().minus(Duration.ofDays(7)).atZone(ZoneOffset.UTC).toLocalDate().toString();
         allForecasts.stream()
                 .filter(metadata -> metadata.getOwner().compareTo(deleteForecastAfter) < 0)
                 .forEach(metadata -> storageProvider.deleteMetadata(metadata.getName(), metadata.getOwner()));

--- a/core/src/test/java/org/jobrunr/configuration/JobRunrConfigurationTest.java
+++ b/core/src/test/java/org/jobrunr/configuration/JobRunrConfigurationTest.java
@@ -217,11 +217,10 @@ class JobRunrConfigurationTest {
         JobRunrConfigurationResult configurationResult = JobRunr.configure()
                 .useStorageProvider(storageProvider)
                 .useJobConfiguration(usingStandardJobConfiguration().andJobRetention(new JobRetentionConfiguration(Duration.ofHours(2), Duration.ofHours(24))))
-                .useBackgroundJobServer()
+                .useBackgroundJobServerIf(true, usingStandardBackgroundJobServerConfiguration(), false)
                 .initialize();
         assertThat(configurationResult.getBackgroundJobServer().getConfiguration())
                 .hasDeleteSucceededJobsAfter(Duration.ofHours(2))
                 .hasPermanentlyDeleteDeletedJobsAfter(Duration.ofHours(24));
-
     }
 }

--- a/core/src/test/java/org/jobrunr/configuration/JobRunrConfigurationTest.java
+++ b/core/src/test/java/org/jobrunr/configuration/JobRunrConfigurationTest.java
@@ -210,4 +210,17 @@ class JobRunrConfigurationTest {
                     .hasMessage("No JsonMapper class is found. Make sure you have either Jackson, Gson or a JsonB compliant library available on your classpath. You may also configure a custom JsonMapper.");
         }
     }
+
+    @Test
+    void initializeUsingJobRetentionOverridesDefaultJobRetentionConfiguration() {
+        JobRunrConfigurationResult configurationResult = JobRunr.configure()
+                .useStorageProvider(storageProvider)
+                .useJobRetention(new JobRetentionConfiguration(Duration.ofHours(2), Duration.ofHours(24)))
+                .useBackgroundJobServer()
+                .initialize();
+        assertThat(configurationResult.getBackgroundJobServer().getConfiguration())
+                .hasDeleteSucceededJobsAfter(Duration.ofHours(2))
+                .hasPermanentlyDeleteDeletedJobsAfter(Duration.ofHours(24));
+
+    }
 }

--- a/core/src/test/java/org/jobrunr/configuration/JobRunrConfigurationTest.java
+++ b/core/src/test/java/org/jobrunr/configuration/JobRunrConfigurationTest.java
@@ -27,6 +27,7 @@ import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.jobrunr.JobRunrAssertions.assertThat;
+import static org.jobrunr.configuration.JobConfiguration.usingStandardJobConfiguration;
 import static org.jobrunr.server.BackgroundJobServerConfiguration.usingStandardBackgroundJobServerConfiguration;
 import static org.jobrunr.server.carbonaware.CarbonAwareJobProcessingConfiguration.usingStandardCarbonAwareJobProcessingConfiguration;
 import static org.mockito.ArgumentMatchers.any;
@@ -215,7 +216,7 @@ class JobRunrConfigurationTest {
     void initializeUsingJobRetentionOverridesDefaultJobRetentionConfiguration() {
         JobRunrConfigurationResult configurationResult = JobRunr.configure()
                 .useStorageProvider(storageProvider)
-                .useJobRetention(new JobRetentionConfiguration(Duration.ofHours(2), Duration.ofHours(24)))
+                .useJobConfiguration(usingStandardJobConfiguration().andJobRetention(new JobRetentionConfiguration(Duration.ofHours(2), Duration.ofHours(24))))
                 .useBackgroundJobServer()
                 .initialize();
         assertThat(configurationResult.getBackgroundJobServer().getConfiguration())

--- a/core/src/testFixtures/java/org/jobrunr/JobRunrAssertions.java
+++ b/core/src/testFixtures/java/org/jobrunr/JobRunrAssertions.java
@@ -26,6 +26,7 @@ import org.jobrunr.server.BackgroundJobServer;
 import org.jobrunr.server.BackgroundJobServerAssert;
 import org.jobrunr.server.BackgroundJobServerConfiguration;
 import org.jobrunr.server.BackgroundJobServerConfigurationAssert;
+import org.jobrunr.server.BackgroundJobServerConfigurationReader;
 import org.jobrunr.server.carbonaware.CarbonAwareJobProcessingConfiguration;
 import org.jobrunr.server.carbonaware.CarbonAwareJobProcessingConfigurationReader;
 import org.jobrunr.server.carbonaware.CarbonIntensityForecast;
@@ -77,6 +78,10 @@ public class JobRunrAssertions extends Assertions {
 
     public static JobRunrMetadataAssert assertThat(JobRunrMetadata metadata) {
         return JobRunrMetadataAssert.assertThat(metadata);
+    }
+
+    public static BackgroundJobServerConfigurationAssert assertThat(BackgroundJobServerConfigurationReader backgroundJobServerConfiguration) {
+        return BackgroundJobServerConfigurationAssert.assertThat(backgroundJobServerConfiguration);
     }
 
     public static BackgroundJobServerConfigurationAssert assertThat(BackgroundJobServerConfiguration backgroundJobServerConfiguration) {

--- a/core/src/testFixtures/java/org/jobrunr/server/BackgroundJobServerConfigurationAssert.java
+++ b/core/src/testFixtures/java/org/jobrunr/server/BackgroundJobServerConfigurationAssert.java
@@ -19,6 +19,10 @@ public class BackgroundJobServerConfigurationAssert extends AbstractAssert<Backg
                 : null);
     }
 
+    public static BackgroundJobServerConfigurationAssert assertThat(BackgroundJobServerConfigurationReader backgroundJobServerConfiguration) {
+        return new BackgroundJobServerConfigurationAssert(backgroundJobServerConfiguration);
+    }
+
     public BackgroundJobServerConfigurationAssert hasName(String name) {
         Assertions.assertThat(actual.getName()).isEqualTo(name);
         return this;
@@ -67,6 +71,16 @@ public class BackgroundJobServerConfigurationAssert extends AbstractAssert<Backg
 
     public BackgroundJobServerConfigurationAssert hasInterruptJobsAwaitDurationOnStopBackgroundJobServer(Duration duration) {
         Assertions.assertThat(actual.getInterruptJobsAwaitDurationOnStopBackgroundJobServer()).isEqualTo(duration);
+        return this;
+    }
+
+    public BackgroundJobServerConfigurationAssert hasDeleteSucceededJobsAfter(Duration duration) {
+        Assertions.assertThat(actual.getDeleteSucceededJobsAfter()).isEqualTo(duration);
+        return this;
+    }
+
+    public BackgroundJobServerConfigurationAssert hasPermanentlyDeleteDeletedJobsAfter(Duration duration) {
+        Assertions.assertThat(actual.getPermanentlyDeleteDeletedJobsAfter()).isEqualTo(duration);
         return this;
     }
 }

--- a/core/src/testFixtures/java/org/jobrunr/storage/BackgroundJobServerStatusTestBuilder.java
+++ b/core/src/testFixtures/java/org/jobrunr/storage/BackgroundJobServerStatusTestBuilder.java
@@ -1,5 +1,6 @@
 package org.jobrunr.storage;
 
+import org.jobrunr.configuration.JobRetentionConfiguration;
 import org.jobrunr.server.BackgroundJobServerConfiguration;
 import org.jobrunr.server.jmx.JobServerStats;
 
@@ -16,8 +17,8 @@ public class BackgroundJobServerStatusTestBuilder {
     private String name = DEFAULT_SERVER_NAME;
     private int workerPoolSize = 10;
     private Duration pollInterval = BackgroundJobServerConfiguration.DEFAULT_POLL_INTERVAL;
-    private Duration deleteSucceededJobsAfter = BackgroundJobServerConfiguration.DEFAULT_DELETE_SUCCEEDED_JOBS_DURATION;
-    private Duration permanentlyDeleteDeletedJobsAfter = BackgroundJobServerConfiguration.DEFAULT_PERMANENTLY_DELETE_JOBS_DURATION;
+    private Duration deleteSucceededJobsAfter = JobRetentionConfiguration.DEFAULT_DELETE_SUCCEEDED_JOBS_DURATION;
+    private Duration permanentlyDeleteDeletedJobsAfter = JobRetentionConfiguration.DEFAULT_PERMANENTLY_DELETE_JOBS_DURATION;
     private Instant firstHeartbeat;
     private Instant lastHeartbeat;
     private boolean running;

--- a/framework-support/jobrunr-micronaut-feature/jobrunr-micronaut/src/main/java/org/jobrunr/micronaut/autoconfigure/JobRunrConfiguration.java
+++ b/framework-support/jobrunr-micronaut-feature/jobrunr-micronaut/src/main/java/org/jobrunr/micronaut/autoconfigure/JobRunrConfiguration.java
@@ -46,6 +46,16 @@ public interface JobRunrConfiguration {
         Optional<Integer> getRetryBackOffTimeSeed();
 
         /**
+         * Sets the duration to wait before changing jobs that are in the SUCCEEDED state to the DELETED state.
+         */
+        Optional<Duration> getDeleteSucceededJobsAfter();
+
+        /**
+         * Sets the duration to wait before permanently deleting jobs that are in the DELETED state.
+         */
+        Optional<Duration> getPermanentlyDeleteDeletedJobsAfter();
+
+        /**
          * Allows to configure the MicroMeter Metrics integration for jobs.
          */
         @NotNull
@@ -158,12 +168,18 @@ public interface JobRunrConfiguration {
 
         /**
          * Sets the duration to wait before changing jobs that are in the SUCCEEDED state to the DELETED state.
+         *
+         * @deprecated use jobrunr.jobs.delete-succeeded-jobs-after
          */
+        @Deprecated
         Optional<Duration> getDeleteSucceededJobsAfter();
 
         /**
          * Sets the duration to wait before permanently deleting jobs that are in the DELETED state.
+         *
+         * @deprecated use jobrunr.jobs.permanently-delete-deleted-jobs-after
          */
+        @Deprecated
         Optional<Duration> getPermanentlyDeleteDeletedJobsAfter();
 
         /**

--- a/framework-support/jobrunr-micronaut-feature/jobrunr-micronaut/src/main/java/org/jobrunr/micronaut/autoconfigure/JobRunrFactory.java
+++ b/framework-support/jobrunr-micronaut-feature/jobrunr-micronaut/src/main/java/org/jobrunr/micronaut/autoconfigure/JobRunrFactory.java
@@ -5,6 +5,7 @@ import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import org.jobrunr.configuration.JobRetentionConfiguration;
 import org.jobrunr.dashboard.JobRunrDashboardWebServer;
 import org.jobrunr.dashboard.JobRunrDashboardWebServerConfiguration;
 import org.jobrunr.jobs.details.CachingJobDetailsGenerator;
@@ -42,6 +43,18 @@ public class JobRunrFactory {
     private JobRunrConfiguration configuration;
 
     @Singleton
+    @Requires(missingBeans = {JobRetentionConfiguration.class})
+    public JobRetentionConfiguration getJobRetentionConfiguration() {
+        Duration deleteSucceededJobsAfter = configuration.getJobs().getDeleteSucceededJobsAfter().isPresent()
+                ? configuration.getJobs().getDeleteSucceededJobsAfter().get()
+                : configuration.getBackgroundJobServer().getDeleteSucceededJobsAfter().orElse(JobRetentionConfiguration.DEFAULT_DELETE_SUCCEEDED_JOBS_DURATION);
+        Duration permanentlyDeleteDeletedJobsAfter = configuration.getJobs().getPermanentlyDeleteDeletedJobsAfter().isPresent()
+                ? configuration.getJobs().getPermanentlyDeleteDeletedJobsAfter().get()
+                : configuration.getBackgroundJobServer().getPermanentlyDeleteDeletedJobsAfter().orElse(JobRetentionConfiguration.DEFAULT_PERMANENTLY_DELETE_JOBS_DURATION);
+        return new JobRetentionConfiguration(deleteSucceededJobsAfter, permanentlyDeleteDeletedJobsAfter);
+    }
+
+    @Singleton
     @Requires(property = "jobrunr.job-scheduler.enabled", value = "true", defaultValue = "true")
     public JobScheduler jobScheduler(StorageProvider storageProvider) {
         final JobDetailsGenerator jobDetailsGenerator = ReflectionUtils.newInstance(configuration.getJobScheduler().getJobDetailsGenerator().orElse(CachingJobDetailsGenerator.class.getName()));
@@ -64,7 +77,7 @@ public class JobRunrFactory {
 
     @Singleton
     @Requires(property = "jobrunr.background-job-server.enabled", value = "true")
-    public BackgroundJobServerConfiguration backgroundJobServerConfiguration(BackgroundJobServerWorkerPolicy backgroundJobServerWorkerPolicy) {
+    public BackgroundJobServerConfiguration backgroundJobServerConfiguration(BackgroundJobServerWorkerPolicy backgroundJobServerWorkerPolicy, JobRetentionConfiguration jobRetentionConfiguration) {
         final BackgroundJobServerConfiguration backgroundJobServerConfiguration = usingStandardBackgroundJobServerConfiguration();
 
         backgroundJobServerConfiguration.andBackgroundJobServerWorkerPolicy(backgroundJobServerWorkerPolicy);
@@ -72,8 +85,8 @@ public class JobRunrFactory {
         configuration.getBackgroundJobServer().getName().ifPresent(backgroundJobServerConfiguration::andName);
         configuration.getBackgroundJobServer().getPollIntervalInSeconds().ifPresent(backgroundJobServerConfiguration::andPollIntervalInSeconds);
         configuration.getBackgroundJobServer().getServerTimeoutPollIntervalMultiplicand().ifPresent(backgroundJobServerConfiguration::andServerTimeoutPollIntervalMultiplicand);
-        configuration.getBackgroundJobServer().getDeleteSucceededJobsAfter().ifPresent(backgroundJobServerConfiguration::andDeleteSucceededJobsAfter);
-        configuration.getBackgroundJobServer().getPermanentlyDeleteDeletedJobsAfter().ifPresent(backgroundJobServerConfiguration::andPermanentlyDeleteDeletedJobsAfter);
+        backgroundJobServerConfiguration.andDeleteSucceededJobsAfter(jobRetentionConfiguration.getDeleteSucceededJobsAfter());
+        backgroundJobServerConfiguration.andPermanentlyDeleteDeletedJobsAfter(jobRetentionConfiguration.getPermanentlyDeleteDeletedJobsAfter());
         configuration.getBackgroundJobServer().getScheduledJobsRequestSize().ifPresent(backgroundJobServerConfiguration::andScheduledJobsRequestSize);
         configuration.getBackgroundJobServer().getCarbonAwaitingJobsRequestSize().ifPresent(backgroundJobServerConfiguration::andCarbonAwaitingJobsRequestSize);
         configuration.getBackgroundJobServer().getOrphanedJobsRequestSize().ifPresent(backgroundJobServerConfiguration::andOrphanedJobsRequestSize);

--- a/framework-support/jobrunr-micronaut-feature/jobrunr-micronaut/src/test/java/org/jobrunr/micronaut/autoconfigure/JobRunrFactoryTest.java
+++ b/framework-support/jobrunr-micronaut-feature/jobrunr-micronaut/src/test/java/org/jobrunr/micronaut/autoconfigure/JobRunrFactoryTest.java
@@ -118,6 +118,30 @@ class JobRunrFactoryTest {
 
     @Test
     @Property(name = "jobrunr.background-job-server.enabled", value = "true")
+    @Property(name = "jobrunr.jobs.delete-succeeded-jobs-after", value = "PT2H")
+    @Property(name = "jobrunr.jobs.permanently-delete-deleted-jobs-after", value = "PT4H")
+    @Property(name = "jobrunr.background-job-server.delete-succeeded-jobs-after", value = "PT1H")
+    @Property(name = "jobrunr.background-job-server.permanently-delete-deleted-jobs-after", value = "PT3H")
+    void backgroundJobServerAutoConfigurationTakesIntoAccountDeleteFilterConfiguredWithJobPropertiesOverServerProperties() {
+        BackgroundJobServerConfiguration backgroundJobServerConfiguration = context.getBean(BackgroundJobServerConfiguration.class);
+        assertThat(backgroundJobServerConfiguration)
+                .hasDeleteSucceededJobsAfter(Duration.ofHours(2))
+                .hasPermanentlyDeleteDeletedJobsAfter(Duration.ofHours(4));
+    }
+
+    @Test
+    @Property(name = "jobrunr.background-job-server.enabled", value = "true")
+    @Property(name = "jobrunr.background-job-server.delete-succeeded-jobs-after", value = "PT1H")
+    @Property(name = "jobrunr.background-job-server.permanently-delete-deleted-jobs-after", value = "PT3H")
+    void backgroundJobServerAutoConfigurationTakesIntoAccountDeleteConfiguration() {
+        BackgroundJobServerConfiguration backgroundJobServerConfiguration = context.getBean(BackgroundJobServerConfiguration.class);
+        assertThat(backgroundJobServerConfiguration)
+                .hasDeleteSucceededJobsAfter(Duration.ofHours(1))
+                .hasPermanentlyDeleteDeletedJobsAfter(Duration.ofHours(3));
+    }
+
+    @Test
+    @Property(name = "jobrunr.background-job-server.enabled", value = "true")
     @Property(name = "jobrunr.background-job-server.name", value = "test")
     void backgroundJobServerAutoConfigurationTakesIntoAccountName() {
         BackgroundJobServer backgroundJobServer = context.getBean(BackgroundJobServer.class);

--- a/framework-support/jobrunr-quarkus-extension/quarkus-jobrunr/src/main/java/org/jobrunr/quarkus/autoconfigure/JobRunrProducer.java
+++ b/framework-support/jobrunr-quarkus-extension/quarkus-jobrunr/src/main/java/org/jobrunr/quarkus/autoconfigure/JobRunrProducer.java
@@ -5,6 +5,7 @@ import io.quarkus.arc.lookup.LookupIfProperty;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import org.jobrunr.configuration.JobRetentionConfiguration;
 import org.jobrunr.jobs.details.CachingJobDetailsGenerator;
 import org.jobrunr.jobs.details.JobDetailsGenerator;
 import org.jobrunr.jobs.mappers.JobMapper;
@@ -17,6 +18,8 @@ import org.jobrunr.utils.mapper.jackson.JacksonJsonMapper;
 import org.jobrunr.utils.mapper.jsonb.JsonbJsonMapper;
 import org.jobrunr.utils.reflection.ReflectionUtils;
 
+import java.time.Duration;
+
 import static java.util.Collections.emptyList;
 
 @Singleton
@@ -26,6 +29,19 @@ public class JobRunrProducer {
     @Inject
     JobRunrProducer(JobRunrRuntimeConfiguration jobRunrRuntimeConfiguration) {
         this.jobRunrRuntimeConfiguration = jobRunrRuntimeConfiguration;
+    }
+
+    @Produces
+    @DefaultBean
+    @Singleton
+    public JobRetentionConfiguration getJobRetentionConfiguration() {
+        Duration deleteSucceededJobsAfter = jobRunrRuntimeConfiguration.jobs().deleteSucceededJobsAfter().isPresent()
+                ? jobRunrRuntimeConfiguration.jobs().deleteSucceededJobsAfter().get()
+                : jobRunrRuntimeConfiguration.backgroundJobServer().deleteSucceededJobsAfter().orElse(JobRetentionConfiguration.DEFAULT_DELETE_SUCCEEDED_JOBS_DURATION);
+        Duration permanentlyDeleteDeletedJobsAfter = jobRunrRuntimeConfiguration.jobs().permanentlyDeleteDeletedJobsAfter().isPresent()
+                ? jobRunrRuntimeConfiguration.jobs().permanentlyDeleteDeletedJobsAfter().get()
+                : jobRunrRuntimeConfiguration.backgroundJobServer().permanentlyDeleteDeletedJobsAfter().orElse(JobRetentionConfiguration.DEFAULT_PERMANENTLY_DELETE_JOBS_DURATION);
+        return new JobRetentionConfiguration(deleteSucceededJobsAfter, permanentlyDeleteDeletedJobsAfter);
     }
 
     @Produces

--- a/framework-support/jobrunr-quarkus-extension/quarkus-jobrunr/src/main/java/org/jobrunr/quarkus/autoconfigure/JobRunrRuntimeConfiguration.java
+++ b/framework-support/jobrunr-quarkus-extension/quarkus-jobrunr/src/main/java/org/jobrunr/quarkus/autoconfigure/JobRunrRuntimeConfiguration.java
@@ -86,6 +86,16 @@ public interface JobRunrRuntimeConfiguration {
         Optional<Integer> retryBackOffTimeSeed();
 
         /**
+         * Sets the duration to wait before changing jobs that are in the SUCCEEDED state to the DELETED state.
+         */
+        Optional<Duration> deleteSucceededJobsAfter();
+
+        /**
+         * Sets the duration to wait before permanently deleting jobs that are in the DELETED state.
+         */
+        Optional<Duration> permanentlyDeleteDeletedJobsAfter();
+
+        /**
          * Configures MicroMeter metrics related to jobs
          */
         MetricsConfiguration metrics();
@@ -164,12 +174,18 @@ public interface JobRunrRuntimeConfiguration {
 
         /**
          * Sets the duration to wait before changing jobs that are in the SUCCEEDED state to the DELETED state.
+         *
+         * @deprecated use quarkus.jobrunr.jobs.delete-succeeded-jobs-after
          */
+        @Deprecated
         Optional<Duration> deleteSucceededJobsAfter();
 
         /**
          * Sets the duration to wait before permanently deleting jobs that are in the DELETED state.
+         *
+         * @deprecated use quarkus.jobrunr.jobs.permanently-delete-deleted-jobs-after
          */
+        @Deprecated
         Optional<Duration> permanentlyDeleteDeletedJobsAfter();
 
         /**

--- a/framework-support/jobrunr-quarkus-extension/quarkus-jobrunr/src/main/java/org/jobrunr/quarkus/autoconfigure/server/JobRunrBackgroundJobServerProducer.java
+++ b/framework-support/jobrunr-quarkus-extension/quarkus-jobrunr/src/main/java/org/jobrunr/quarkus/autoconfigure/server/JobRunrBackgroundJobServerProducer.java
@@ -6,6 +6,7 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import org.jobrunr.configuration.JobRetentionConfiguration;
 import org.jobrunr.jobs.filters.RetryFilter;
 import org.jobrunr.quarkus.autoconfigure.JobRunrRuntimeConfiguration;
 import org.jobrunr.server.BackgroundJobServer;
@@ -46,7 +47,7 @@ public class JobRunrBackgroundJobServerProducer {
     @Produces
     @DefaultBean
     @Singleton
-    BackgroundJobServerConfiguration backgroundJobServerConfiguration(BackgroundJobServerWorkerPolicy backgroundJobServerWorkerPolicy) {
+    BackgroundJobServerConfiguration backgroundJobServerConfiguration(BackgroundJobServerWorkerPolicy backgroundJobServerWorkerPolicy, JobRetentionConfiguration jobRetentionConfiguration) {
         if (jobRunrRuntimeConfiguration.backgroundJobServer().enabled()) {
             final BackgroundJobServerConfiguration backgroundJobServerConfiguration = usingStandardBackgroundJobServerConfiguration();
 
@@ -55,8 +56,8 @@ public class JobRunrBackgroundJobServerProducer {
             jobRunrRuntimeConfiguration.backgroundJobServer().name().ifPresent(backgroundJobServerConfiguration::andName);
             jobRunrRuntimeConfiguration.backgroundJobServer().pollIntervalInSeconds().ifPresent(backgroundJobServerConfiguration::andPollIntervalInSeconds);
             jobRunrRuntimeConfiguration.backgroundJobServer().serverTimeoutPollIntervalMultiplicand().ifPresent(backgroundJobServerConfiguration::andServerTimeoutPollIntervalMultiplicand);
-            jobRunrRuntimeConfiguration.backgroundJobServer().deleteSucceededJobsAfter().ifPresent(backgroundJobServerConfiguration::andDeleteSucceededJobsAfter);
-            jobRunrRuntimeConfiguration.backgroundJobServer().permanentlyDeleteDeletedJobsAfter().ifPresent(backgroundJobServerConfiguration::andPermanentlyDeleteDeletedJobsAfter);
+            backgroundJobServerConfiguration.andDeleteSucceededJobsAfter(jobRetentionConfiguration.getDeleteSucceededJobsAfter());
+            backgroundJobServerConfiguration.andPermanentlyDeleteDeletedJobsAfter(jobRetentionConfiguration.getPermanentlyDeleteDeletedJobsAfter());
             jobRunrRuntimeConfiguration.backgroundJobServer().carbonAwaitingJobsRequestSize().ifPresent(backgroundJobServerConfiguration::andCarbonAwaitingJobsRequestSize);
             jobRunrRuntimeConfiguration.backgroundJobServer().scheduledJobsRequestSize().ifPresent(backgroundJobServerConfiguration::andScheduledJobsRequestSize);
             jobRunrRuntimeConfiguration.backgroundJobServer().orphanedJobsRequestSize().ifPresent(backgroundJobServerConfiguration::andOrphanedJobsRequestSize);

--- a/framework-support/jobrunr-quarkus-extension/quarkus-jobrunr/src/test/java/org/jobrunr/quarkus/autoconfigure/server/JobRunrBackgroundJobServerProducerTest.java
+++ b/framework-support/jobrunr-quarkus-extension/quarkus-jobrunr/src/test/java/org/jobrunr/quarkus/autoconfigure/server/JobRunrBackgroundJobServerProducerTest.java
@@ -6,6 +6,7 @@ import io.quarkus.test.component.TestConfigProperty;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import org.assertj.core.api.Assertions;
+import org.jobrunr.quarkus.autoconfigure.JobRunrProducer;
 import org.jobrunr.server.BackgroundJobServer;
 import org.jobrunr.server.BackgroundJobServerConfiguration;
 import org.jobrunr.server.carbonaware.CarbonAwareJobProcessingConfigurationReader;
@@ -15,7 +16,8 @@ import java.time.Duration;
 
 import static org.jobrunr.JobRunrAssertions.assertThat;
 
-@QuarkusComponentTest(JobRunrBackgroundJobServerProducer.class) // needed to create all other beans otherwise the extension doesn't pick them up.
+// needed to create all other beans otherwise the extension doesn't pick them up.
+@QuarkusComponentTest({JobRunrProducer.class, JobRunrBackgroundJobServerProducer.class})
 public class JobRunrBackgroundJobServerProducerTest {
 
     @Inject
@@ -123,5 +125,33 @@ public class JobRunrBackgroundJobServerProducerTest {
 
         assertThat(backgroundJobServerConfigurationInstance.get())
                 .hasInterruptJobsAwaitDurationOnStopBackgroundJobServer(Duration.ofSeconds(20));
+    }
+
+    @Test
+    @TestConfigProperty(key = "quarkus.jobrunr.background-job-server.enabled", value = "true")
+    @TestConfigProperty(key = "quarkus.jobrunr.jobs.delete-succeeded-jobs-after", value = "PT2H")
+    @TestConfigProperty(key = "quarkus.jobrunr.jobs.permanently-delete-deleted-jobs-after", value = "PT4H")
+    @TestConfigProperty(key = "quarkus.jobrunr.background-job-server.delete-succeeded-jobs-after", value = "PT1H")
+    @TestConfigProperty(key = "quarkus.jobrunr.background-job-server.permanently-delete-deleted-jobs-after", value = "PT3H")
+    void backgroundJobServerAutoConfigurationTakesIntoAccountDeleteFilterConfiguredWithJobPropertiesOverServerProperties() {
+        assertThat(backgroundJobServerConfigurationInstance.isResolvable()).isTrue();
+        Assertions.assertThat(backgroundJobServerConfigurationInstance.get()).isInstanceOf(BackgroundJobServerConfiguration.class);
+
+        assertThat(backgroundJobServerConfigurationInstance.get())
+                .hasDeleteSucceededJobsAfter(Duration.ofHours(2))
+                .hasPermanentlyDeleteDeletedJobsAfter(Duration.ofHours(4));
+    }
+
+    @Test
+    @TestConfigProperty(key = "quarkus.jobrunr.background-job-server.enabled", value = "true")
+    @TestConfigProperty(key = "quarkus.jobrunr.background-job-server.delete-succeeded-jobs-after", value = "PT1H")
+    @TestConfigProperty(key = "quarkus.jobrunr.background-job-server.permanently-delete-deleted-jobs-after", value = "PT3H")
+    void backgroundJobServerAutoConfigurationTakesIntoAccountDeleteConfiguration() {
+        assertThat(backgroundJobServerConfigurationInstance.isResolvable()).isTrue();
+        Assertions.assertThat(backgroundJobServerConfigurationInstance.get()).isInstanceOf(BackgroundJobServerConfiguration.class);
+
+        assertThat(backgroundJobServerConfigurationInstance.get())
+                .hasDeleteSucceededJobsAfter(Duration.ofHours(1))
+                .hasPermanentlyDeleteDeletedJobsAfter(Duration.ofHours(3));
     }
 }

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
@@ -1,5 +1,6 @@
 package org.jobrunr.spring.autoconfigure;
 
+import org.jobrunr.configuration.JobRetentionConfiguration;
 import org.jobrunr.dashboard.JobRunrDashboardWebServer;
 import org.jobrunr.dashboard.JobRunrDashboardWebServerConfiguration;
 import org.jobrunr.jobs.details.JobDetailsGenerator;
@@ -38,8 +39,10 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.util.ClassUtils;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import static java.util.Collections.emptyList;
@@ -56,6 +59,18 @@ import static org.jobrunr.server.BackgroundJobServerConfiguration.usingStandardB
 @EnableConfigurationProperties(JobRunrProperties.class)
 @ComponentScan(basePackages = {"org.jobrunr.scheduling"})
 public class JobRunrAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public JobRetentionConfiguration jobRetentionConfiguration(Environment environment, JobRunrProperties jobRunrProperties) {
+        Duration deleteSucceededJobsAfter = environment.containsProperty("jobrunr.jobs.delete-succeeded-jobs-after")
+                ? jobRunrProperties.getJobs().getDeleteSucceededJobsAfter()
+                : jobRunrProperties.getBackgroundJobServer().getDeleteSucceededJobsAfter();
+        Duration permanentlyDeleteDeletedJobsAfter = environment.containsProperty("jobrunr.jobs.permanently-delete-deleted-jobs-after")
+                ? jobRunrProperties.getJobs().getPermanentlyDeleteDeletedJobsAfter()
+                : jobRunrProperties.getBackgroundJobServer().getPermanentlyDeleteDeletedJobsAfter();
+        return new JobRetentionConfiguration(deleteSucceededJobsAfter, permanentlyDeleteDeletedJobsAfter);
+    }
 
     @Bean
     public JobRunrStarter jobRunrStarter(Optional<BackgroundJobServer> backgroundJobServer, Optional<JobRunrDashboardWebServer> webServer) {
@@ -99,7 +114,7 @@ public class JobRunrAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnProperty(prefix = "jobrunr.background-job-server", name = "enabled", havingValue = "true")
-    public BackgroundJobServerConfiguration backgroundJobServerConfiguration(JobRunrProperties properties, BackgroundJobServerWorkerPolicy backgroundJobServerWorkerPolicy) {
+    public BackgroundJobServerConfiguration backgroundJobServerConfiguration(JobRunrProperties properties, BackgroundJobServerWorkerPolicy backgroundJobServerWorkerPolicy, JobRetentionConfiguration jobRetentionConfiguration) {
         PropertyMapper map = PropertyMapper.get();
         BackgroundJobServerConfiguration backgroundJobServerConfiguration = usingStandardBackgroundJobServerConfiguration();
         JobRunrProperties.BackgroundJobServer backgroundJobServerProperties = properties.getBackgroundJobServer();
@@ -109,8 +124,8 @@ public class JobRunrAutoConfiguration {
         map.from(backgroundJobServerProperties::getName).whenNonNull().to(backgroundJobServerConfiguration::andName);
         map.from(backgroundJobServerProperties::getPollIntervalInSeconds).to(backgroundJobServerConfiguration::andPollIntervalInSeconds);
         map.from(backgroundJobServerProperties::getServerTimeoutPollIntervalMultiplicand).to(backgroundJobServerConfiguration::andServerTimeoutPollIntervalMultiplicand);
-        map.from(backgroundJobServerProperties::getDeleteSucceededJobsAfter).to(backgroundJobServerConfiguration::andDeleteSucceededJobsAfter);
-        map.from(backgroundJobServerProperties::getPermanentlyDeleteDeletedJobsAfter).to(backgroundJobServerConfiguration::andPermanentlyDeleteDeletedJobsAfter);
+        map.from(jobRetentionConfiguration::getDeleteSucceededJobsAfter).to(backgroundJobServerConfiguration::andDeleteSucceededJobsAfter);
+        map.from(jobRetentionConfiguration::getPermanentlyDeleteDeletedJobsAfter).to(backgroundJobServerConfiguration::andPermanentlyDeleteDeletedJobsAfter);
         map.from(backgroundJobServerProperties::getScheduledJobsRequestSize).to(backgroundJobServerConfiguration::andScheduledJobsRequestSize);
         map.from(backgroundJobServerProperties::getCarbonAwaitingJobsRequestSize).to(backgroundJobServerConfiguration::andCarbonAwaitingJobsRequestSize);
         map.from(backgroundJobServerProperties::getOrphanedJobsRequestSize).to(backgroundJobServerConfiguration::andOrphanedJobsRequestSize);

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrProperties.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrProperties.java
@@ -325,6 +325,7 @@ public class JobRunrProperties {
          *
          * @deprecated use jobrunr.jobs.permanently-delete-deleted-jobs-after
          */
+        @Deprecated
         @DurationUnit(HOURS)
         private Duration permanentlyDeleteDeletedJobsAfter = Duration.ofHours(72);
 

--- a/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrProperties.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrProperties.java
@@ -11,6 +11,8 @@ import java.time.Duration;
 import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.jobrunr.configuration.JobRetentionConfiguration.DEFAULT_DELETE_SUCCEEDED_JOBS_DURATION;
+import static org.jobrunr.configuration.JobRetentionConfiguration.DEFAULT_PERMANENTLY_DELETE_JOBS_DURATION;
 import static org.jobrunr.server.BackgroundJobServerConfiguration.DEFAULT_PAGE_REQUEST_SIZE;
 
 @ConfigurationProperties(prefix = "jobrunr")
@@ -155,7 +157,21 @@ public class JobRunrProperties {
         /**
          * Configures the seed for the exponential back-off when jobs are retried in case of an Exception.
          */
-        private int backOffTimeSeed = RetryFilter.DEFAULT_BACKOFF_POLICY_TIME_SEED;
+        private int retryBackOffTimeSeed = RetryFilter.DEFAULT_BACKOFF_POLICY_TIME_SEED;
+
+        /**
+         * Sets the duration to wait before changing jobs that are in the SUCCEEDED state to the DELETED state. If a duration suffix
+         * is not specified, hours will be used.
+         */
+        @DurationUnit(HOURS)
+        private Duration deleteSucceededJobsAfter = DEFAULT_DELETE_SUCCEEDED_JOBS_DURATION;
+
+        /**
+         * Sets the duration to wait before permanently deleting jobs that are in the DELETED state. If a duration suffix
+         * is not specified, hours will be used.
+         */
+        @DurationUnit(HOURS)
+        private Duration permanentlyDeleteDeletedJobsAfter = DEFAULT_PERMANENTLY_DELETE_JOBS_DURATION;
 
         /**
          * Configures MicroMeter metrics related to jobs
@@ -171,11 +187,27 @@ public class JobRunrProperties {
         }
 
         public int getRetryBackOffTimeSeed() {
-            return backOffTimeSeed;
+            return retryBackOffTimeSeed;
         }
 
-        public void setRetryBackOffTimeSeed(int backOffTimeSeed) {
-            this.backOffTimeSeed = backOffTimeSeed;
+        public void setRetryBackOffTimeSeed(int retryBackOffTimeSeed) {
+            this.retryBackOffTimeSeed = retryBackOffTimeSeed;
+        }
+
+        public Duration getDeleteSucceededJobsAfter() {
+            return deleteSucceededJobsAfter;
+        }
+
+        public void setDeleteSucceededJobsAfter(Duration deleteSucceededJobsAfter) {
+            this.deleteSucceededJobsAfter = deleteSucceededJobsAfter;
+        }
+
+        public Duration getPermanentlyDeleteDeletedJobsAfter() {
+            return permanentlyDeleteDeletedJobsAfter;
+        }
+
+        public void setPermanentlyDeleteDeletedJobsAfter(Duration permanentlyDeleteDeletedJobsAfter) {
+            this.permanentlyDeleteDeletedJobsAfter = permanentlyDeleteDeletedJobsAfter;
         }
 
         public Metrics getMetrics() {
@@ -280,16 +312,22 @@ public class JobRunrProperties {
         /**
          * Sets the duration to wait before changing jobs that are in the SUCCEEDED state to the DELETED state. If a duration suffix
          * is not specified, hours will be used.
+         *
+         * @deprecated use jobrunr.jobs.delete-succeeded-jobs-after
          */
+        @Deprecated
         @DurationUnit(HOURS)
         private Duration deleteSucceededJobsAfter = Duration.ofHours(36);
 
         /**
          * Sets the duration to wait before permanently deleting jobs that are in the DELETED state. If a duration suffix
          * is not specified, hours will be used.
+         *
+         * @deprecated use jobrunr.jobs.permanently-delete-deleted-jobs-after
          */
         @DurationUnit(HOURS)
         private Duration permanentlyDeleteDeletedJobsAfter = Duration.ofHours(72);
+
 
         /**
          * Sets the duration to wait before interrupting threads/jobs when the server is stopped. If a duration suffix

--- a/framework-support/jobrunr-spring-boot-3-starter/src/test/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfigurationTest.java
+++ b/framework-support/jobrunr-spring-boot-3-starter/src/test/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfigurationTest.java
@@ -195,6 +195,40 @@ public class JobRunrAutoConfigurationTest {
     }
 
     @Test
+    void backgroundJobServerAutoConfigurationTakesIntoAccountDeleteConfigurationWithJobPropertiesOverServerProperties() {
+        this.contextRunner
+                .withPropertyValues(
+                        "jobrunr.background-job-server.enabled=true",
+                        "jobrunr.jobs.delete-succeeded-jobs-after=PT2H",
+                        "jobrunr.jobs.permanently-delete-deleted-jobs-after=PT4H",
+                        "jobrunr.background-job-server.delete-succeeded-jobs-after=PT1H",
+                        "jobrunr.background-job-server.permanently-delete-deleted-jobs-after=PT3H")
+                .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
+                    assertThat(context).hasSingleBean(BackgroundJobServer.class);
+                    BackgroundJobServerConfiguration backgroundJobServerConfiguration = context.getBean(BackgroundJobServerConfiguration.class);
+                    assertThat(backgroundJobServerConfiguration)
+                            .hasDeleteSucceededJobsAfter(Duration.ofHours(2))
+                            .hasPermanentlyDeleteDeletedJobsAfter(Duration.ofHours(4));
+                });
+    }
+
+    @Test
+    void backgroundJobServerAutoConfigurationTakesIntoAccountDeleteConfiguration() {
+        this.contextRunner
+                .withPropertyValues(
+                        "jobrunr.background-job-server.enabled=true",
+                        "jobrunr.background-job-server.delete-succeeded-jobs-after=PT1H",
+                        "jobrunr.background-job-server.permanently-delete-deleted-jobs-after=PT3H")
+                .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
+                    assertThat(context).hasSingleBean(BackgroundJobServer.class);
+                    BackgroundJobServerConfiguration backgroundJobServerConfiguration = context.getBean(BackgroundJobServerConfiguration.class);
+                    assertThat(backgroundJobServerConfiguration)
+                            .hasDeleteSucceededJobsAfter(Duration.ofHours(1))
+                            .hasPermanentlyDeleteDeletedJobsAfter(Duration.ofHours(3));
+                });
+    }
+
+    @Test
     void backgroundJobServerAutoConfigurationTakesIntoAccountName() {
         this.contextRunner
                 .withPropertyValues("jobrunr.background-job-server.enabled=true")

--- a/framework-support/jobrunr-spring-boot-4-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
+++ b/framework-support/jobrunr-spring-boot-4-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfiguration.java
@@ -1,5 +1,6 @@
 package org.jobrunr.spring.autoconfigure;
 
+import org.jobrunr.configuration.JobRetentionConfiguration;
 import org.jobrunr.dashboard.JobRunrDashboardWebServer;
 import org.jobrunr.dashboard.JobRunrDashboardWebServerConfiguration;
 import org.jobrunr.jobs.details.JobDetailsGenerator;
@@ -38,8 +39,10 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.util.ClassUtils;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import static java.util.Collections.emptyList;
@@ -51,11 +54,22 @@ import static org.jobrunr.server.BackgroundJobServerConfiguration.usingStandardB
 /**
  * A Spring Boot AutoConfiguration class for JobRunr
  */
-@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
 @AutoConfiguration
 @EnableConfigurationProperties(JobRunrProperties.class)
 @ComponentScan(basePackages = {"org.jobrunr.scheduling"})
 public class JobRunrAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public JobRetentionConfiguration jobRetentionConfiguration(Environment environment, JobRunrProperties jobRunrProperties) {
+        Duration deleteSucceededJobsAfter = environment.containsProperty("jobrunr.jobs.delete-succeeded-jobs-after")
+                ? jobRunrProperties.getJobs().getDeleteSucceededJobsAfter()
+                : jobRunrProperties.getBackgroundJobServer().getDeleteSucceededJobsAfter();
+        Duration permanentlyDeleteDeletedJobsAfter = environment.containsProperty("jobrunr.jobs.permanently-delete-deleted-jobs-after")
+                ? jobRunrProperties.getJobs().getPermanentlyDeleteDeletedJobsAfter()
+                : jobRunrProperties.getBackgroundJobServer().getPermanentlyDeleteDeletedJobsAfter();
+        return new JobRetentionConfiguration(deleteSucceededJobsAfter, permanentlyDeleteDeletedJobsAfter);
+    }
 
     @Bean
     public JobRunrStarter jobRunrStarter(Optional<BackgroundJobServer> backgroundJobServer, Optional<JobRunrDashboardWebServer> webServer) {
@@ -99,7 +113,7 @@ public class JobRunrAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnProperty(prefix = "jobrunr.background-job-server", name = "enabled", havingValue = "true")
-    public BackgroundJobServerConfiguration backgroundJobServerConfiguration(JobRunrProperties properties, BackgroundJobServerWorkerPolicy backgroundJobServerWorkerPolicy) {
+    public BackgroundJobServerConfiguration backgroundJobServerConfiguration(JobRunrProperties properties, BackgroundJobServerWorkerPolicy backgroundJobServerWorkerPolicy, JobRetentionConfiguration jobRetentionConfiguration) {
         PropertyMapper map = PropertyMapper.get();
         BackgroundJobServerConfiguration backgroundJobServerConfiguration = usingStandardBackgroundJobServerConfiguration();
         JobRunrProperties.BackgroundJobServer backgroundJobServerProperties = properties.getBackgroundJobServer();
@@ -109,8 +123,8 @@ public class JobRunrAutoConfiguration {
         map.from(backgroundJobServerProperties::getName).to(backgroundJobServerConfiguration::andName);
         map.from(backgroundJobServerProperties::getPollIntervalInSeconds).to(backgroundJobServerConfiguration::andPollIntervalInSeconds);
         map.from(backgroundJobServerProperties::getServerTimeoutPollIntervalMultiplicand).to(backgroundJobServerConfiguration::andServerTimeoutPollIntervalMultiplicand);
-        map.from(backgroundJobServerProperties::getDeleteSucceededJobsAfter).to(backgroundJobServerConfiguration::andDeleteSucceededJobsAfter);
-        map.from(backgroundJobServerProperties::getPermanentlyDeleteDeletedJobsAfter).to(backgroundJobServerConfiguration::andPermanentlyDeleteDeletedJobsAfter);
+        map.from(jobRetentionConfiguration::getDeleteSucceededJobsAfter).to(backgroundJobServerConfiguration::andDeleteSucceededJobsAfter);
+        map.from(jobRetentionConfiguration::getPermanentlyDeleteDeletedJobsAfter).to(backgroundJobServerConfiguration::andPermanentlyDeleteDeletedJobsAfter);
         map.from(backgroundJobServerProperties::getScheduledJobsRequestSize).to(backgroundJobServerConfiguration::andScheduledJobsRequestSize);
         map.from(backgroundJobServerProperties::getCarbonAwaitingJobsRequestSize).to(backgroundJobServerConfiguration::andCarbonAwaitingJobsRequestSize);
         map.from(backgroundJobServerProperties::getOrphanedJobsRequestSize).to(backgroundJobServerConfiguration::andOrphanedJobsRequestSize);

--- a/framework-support/jobrunr-spring-boot-4-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrProperties.java
+++ b/framework-support/jobrunr-spring-boot-4-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrProperties.java
@@ -11,6 +11,8 @@ import java.time.Duration;
 import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.jobrunr.configuration.JobRetentionConfiguration.DEFAULT_DELETE_SUCCEEDED_JOBS_DURATION;
+import static org.jobrunr.configuration.JobRetentionConfiguration.DEFAULT_PERMANENTLY_DELETE_JOBS_DURATION;
 import static org.jobrunr.server.BackgroundJobServerConfiguration.DEFAULT_PAGE_REQUEST_SIZE;
 
 @ConfigurationProperties(prefix = "jobrunr")
@@ -155,7 +157,21 @@ public class JobRunrProperties {
         /**
          * Configures the seed for the exponential back-off when jobs are retried in case of an Exception.
          */
-        private int backOffTimeSeed = RetryFilter.DEFAULT_BACKOFF_POLICY_TIME_SEED;
+        private int retryBackOffTimeSeed = RetryFilter.DEFAULT_BACKOFF_POLICY_TIME_SEED;
+
+        /**
+         * Sets the duration to wait before changing jobs that are in the SUCCEEDED state to the DELETED state. If a duration suffix
+         * is not specified, hours will be used.
+         */
+        @DurationUnit(HOURS)
+        private Duration deleteSucceededJobsAfter = DEFAULT_DELETE_SUCCEEDED_JOBS_DURATION;
+
+        /**
+         * Sets the duration to wait before permanently deleting jobs that are in the DELETED state. If a duration suffix
+         * is not specified, hours will be used.
+         */
+        @DurationUnit(HOURS)
+        private Duration permanentlyDeleteDeletedJobsAfter = DEFAULT_PERMANENTLY_DELETE_JOBS_DURATION;
 
         /**
          * Configures MicroMeter metrics related to jobs
@@ -171,11 +187,27 @@ public class JobRunrProperties {
         }
 
         public int getRetryBackOffTimeSeed() {
-            return backOffTimeSeed;
+            return retryBackOffTimeSeed;
         }
 
-        public void setRetryBackOffTimeSeed(int backOffTimeSeed) {
-            this.backOffTimeSeed = backOffTimeSeed;
+        public void setRetryBackOffTimeSeed(int retryBackOffTimeSeed) {
+            this.retryBackOffTimeSeed = retryBackOffTimeSeed;
+        }
+
+        public Duration getDeleteSucceededJobsAfter() {
+            return deleteSucceededJobsAfter;
+        }
+
+        public void setDeleteSucceededJobsAfter(Duration deleteSucceededJobsAfter) {
+            this.deleteSucceededJobsAfter = deleteSucceededJobsAfter;
+        }
+
+        public Duration getPermanentlyDeleteDeletedJobsAfter() {
+            return permanentlyDeleteDeletedJobsAfter;
+        }
+
+        public void setPermanentlyDeleteDeletedJobsAfter(Duration permanentlyDeleteDeletedJobsAfter) {
+            this.permanentlyDeleteDeletedJobsAfter = permanentlyDeleteDeletedJobsAfter;
         }
 
         public Metrics getMetrics() {
@@ -280,13 +312,18 @@ public class JobRunrProperties {
         /**
          * Sets the duration to wait before changing jobs that are in the SUCCEEDED state to the DELETED state. If a duration suffix
          * is not specified, hours will be used.
+         *
+         * @deprecated use jobrunr.jobs.delete-succeeded-jobs-after
          */
+        @Deprecated
         @DurationUnit(HOURS)
         private Duration deleteSucceededJobsAfter = Duration.ofHours(36);
 
         /**
          * Sets the duration to wait before permanently deleting jobs that are in the DELETED state. If a duration suffix
          * is not specified, hours will be used.
+         *
+         * @deprecated use jobrunr.jobs.permanently-delete-deleted-jobs-after
          */
         @DurationUnit(HOURS)
         private Duration permanentlyDeleteDeletedJobsAfter = Duration.ofHours(72);

--- a/framework-support/jobrunr-spring-boot-4-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrProperties.java
+++ b/framework-support/jobrunr-spring-boot-4-starter/src/main/java/org/jobrunr/spring/autoconfigure/JobRunrProperties.java
@@ -325,6 +325,7 @@ public class JobRunrProperties {
          *
          * @deprecated use jobrunr.jobs.permanently-delete-deleted-jobs-after
          */
+        @Deprecated
         @DurationUnit(HOURS)
         private Duration permanentlyDeleteDeletedJobsAfter = Duration.ofHours(72);
 

--- a/framework-support/jobrunr-spring-boot-4-starter/src/test/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfigurationTest.java
+++ b/framework-support/jobrunr-spring-boot-4-starter/src/test/java/org/jobrunr/spring/autoconfigure/JobRunrAutoConfigurationTest.java
@@ -70,7 +70,7 @@ public class JobRunrAutoConfigurationTest {
         this.contextRunner
                 .withUserConfiguration(InMemoryStorageProvider.class)
                 .withClassLoader(new FilteredClassLoader(Gson.class, com.fasterxml.jackson.databind.ObjectMapper.class, kotlinx.serialization.json.Json.class))
-                .run((context) -> assertThat(context).getBean("jobRunrJsonMapper").matches(x -> "Jackson3JsonMapper".equals(x.getClass().getSimpleName())));
+                .run((context) -> assertThat(context).getBean("jobRunrJsonMapper").matches(x -> "Jackson3JsonMapper" .equals(x.getClass().getSimpleName())));
     }
 
     @Test
@@ -78,7 +78,7 @@ public class JobRunrAutoConfigurationTest {
         this.contextRunner
                 .withUserConfiguration(InMemoryStorageProvider.class)
                 .withClassLoader(new FilteredClassLoader(Gson.class, tools.jackson.databind.ObjectMapper.class, kotlinx.serialization.json.Json.class))
-                .run((context) -> assertThat(context).getBean("jobRunrJsonMapper").matches(x -> "JacksonJsonMapper".equals(x.getClass().getSimpleName())));
+                .run((context) -> assertThat(context).getBean("jobRunrJsonMapper").matches(x -> "JacksonJsonMapper" .equals(x.getClass().getSimpleName())));
     }
 
     @Test
@@ -198,6 +198,40 @@ public class JobRunrAutoConfigurationTest {
                 .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
                     assertThat(context).hasSingleBean(BackgroundJobServer.class);
                     assertThat(context).doesNotHaveBean(JobRunrDashboardWebServer.class);
+                });
+    }
+
+    @Test
+    void backgroundJobServerAutoConfigurationTakesIntoAccountDeleteConfigurationWithJobPropertiesOverServerProperties() {
+        this.contextRunner
+                .withPropertyValues(
+                        "jobrunr.background-job-server.enabled=true",
+                        "jobrunr.jobs.delete-succeeded-jobs-after=PT2H",
+                        "jobrunr.jobs.permanently-delete-deleted-jobs-after=PT4H",
+                        "jobrunr.background-job-server.delete-succeeded-jobs-after=PT1H",
+                        "jobrunr.background-job-server.permanently-delete-deleted-jobs-after=PT3H")
+                .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
+                    assertThat(context).hasSingleBean(BackgroundJobServer.class);
+                    BackgroundJobServerConfiguration backgroundJobServerConfiguration = context.getBean(BackgroundJobServerConfiguration.class);
+                    assertThat(backgroundJobServerConfiguration)
+                            .hasDeleteSucceededJobsAfter(Duration.ofHours(2))
+                            .hasPermanentlyDeleteDeletedJobsAfter(Duration.ofHours(4));
+                });
+    }
+
+    @Test
+    void backgroundJobServerAutoConfigurationTakesIntoAccountDeleteConfiguration() {
+        this.contextRunner
+                .withPropertyValues(
+                        "jobrunr.background-job-server.enabled=true",
+                        "jobrunr.background-job-server.delete-succeeded-jobs-after=PT1H",
+                        "jobrunr.background-job-server.permanently-delete-deleted-jobs-after=PT3H")
+                .withUserConfiguration(InMemoryStorageProvider.class).run((context) -> {
+                    assertThat(context).hasSingleBean(BackgroundJobServer.class);
+                    BackgroundJobServerConfiguration backgroundJobServerConfiguration = context.getBean(BackgroundJobServerConfiguration.class);
+                    assertThat(backgroundJobServerConfiguration)
+                            .hasDeleteSucceededJobsAfter(Duration.ofHours(1))
+                            .hasPermanentlyDeleteDeletedJobsAfter(Duration.ofHours(3));
                 });
     }
 


### PR DESCRIPTION
Aligns with JobRunr Pro, where job retention configuration needs to be available to all JobRunr components (dashboard, workers, schedulers) rather than only to the background job server.

### `JobRetentionConfiguration`

A new immutable holder (`org.jobrunr.configuration`) for `deleteSucceededJobsAfter` and `permanentlyDeleteDeletedJobsAfter`. The defaults (36h / 72h) move here from `BackgroundJobServerConfiguration`.

### Fluent API

```java
// OSS

JobRunr.configure()
       .useJobRetention(JobConfiguration.usingStandardJobConfiguration().andJobRetention(new JobRetentionConfiguration(Duration.ofHours(2), Duration.ofHours(24))))
       // ...
       .initialize();
       
       
 // Pro
 
 
JobRunr.configure()
       .useJobRetention(JobConfiguration.usingStandardJobConfiguration().andJobRetention(new JobRetentionConfiguration(Duration.ofHours(2), null, Duration.ofHours(24))))
       // ...
       .initialize();
```

When set, this takes precedence over whatever is configured on the `BackgroundJobServerConfiguration`. The retention setters on `BackgroundJobServerConfiguration` (`andDeleteSucceededJobsAfter`, `andPermanentlyDeleteDeletedJobsAfter`) are now deprecated.

### Properties

Retention moves from `background-job-server` to `jobs`. The old properties are deprecated and still work: if the `jobs` property is not set, we fall back to `background-job-server`. Where both are set, `jobs` wins.

New syntax:

```
jobrunr.jobs.delete-succeeded-jobs-after=PT2H
#jobrunr.jobs.delete-failed-jobs-after (Pro only)
jobrunr.jobs.permanently-delete-deleted-jobs-after=PT4H
```

Old syntax (dropped in v10):

```
jobrunr.background-job-server.delete-succeeded-jobs-after=PT1H
jobrunr.background-job-server.permanently-delete-deleted-jobs-after=PT3H
```

Quarkus uses the `quarkus.jobrunr.` prefix for both.

### Also in this PR

The retention period for carbon intensity forecasts no longer derives from the job retention config and is now a fixed 7 days.